### PR TITLE
Add script for aggregating lane and trail networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 scripts/census/data/*
+scripts/lanes/data/*
+scripts/lanes/node_modules/*

--- a/scripts/lanes/README.md
+++ b/scripts/lanes/README.md
@@ -1,0 +1,8 @@
+This directory contains a script for aggregating connected networks of bike lanes and trails in DC.
+
+# Steps:
+
+* create a `data` subdirectory
+* add the bike lanes and bike trails data to it (`data/Bicycle_Lanes/Bicycle_Lanes.shp` and `data/Bike_Trails/Bike_Trails.shp` should exist)
+* run the `convert.sh` script to convert to geojson
+* run the `cluster.js` script, which should generate a `data/out.geojson` file with the aggregated network

--- a/scripts/lanes/cluster.js
+++ b/scripts/lanes/cluster.js
@@ -41,7 +41,6 @@ for (let i = 0; i < features.length; i++) {
 
                 intersects = turf.booleanOverlap(f1, f2);
             } catch(err) {
-                console.log("e1", err);
                 try {
                     let f1 = features[i], f2 = features[match.idx];
 
@@ -49,12 +48,12 @@ for (let i = 0; i < features.length; i++) {
                     if (f2.geometry.type == "MultiLineString" && f1.geometry.type == "LineString") f1 = turf.multiLineString([f1.geometry.coordinates]);
 
                     intersects = turf.booleanOverlap(f1, f2);
-                } catch(err2) { console.log("e2", err2); }
+                } catch(err2) {}
             }
 
             if (intersects) {
                 uf.union(i, match.idx);
-                console.log(i, match.idx);
+                console.log("merging", i, match.idx);
             }
         }
     }
@@ -86,4 +85,3 @@ let out = {
 }
 
 fs.writeFileSync("data/out.geojson", JSON.stringify(out, null, 4));
-//console.log(lengths);

--- a/scripts/lanes/cluster.js
+++ b/scripts/lanes/cluster.js
@@ -1,0 +1,89 @@
+let UnionFind = require('node-union-find'),
+    fs = require('fs'),
+    turf = require('@turf/turf'),
+    rbush = require('rbush'),
+    colorvert = require('colorvert');
+
+let lanes_data = JSON.parse(fs.readFileSync('data/Bicycle_Lanes.geojson'));
+let trails_data = JSON.parse(fs.readFileSync('data/Bike_Trails.geojson'));
+let features = [
+    ...lanes_data.features.map((f) => { f.properties.source_dataset = 'lanes'; return f; }),
+    ...trails_data.features.map((f) => { f.properties.source_dataset = 'trails'; return f; })
+]
+
+let uf = new UnionFind([...features.keys()]);
+
+let buffered = [],
+    bboxes = [],
+    tree = rbush();
+for (let i = 0; i < features.length; i++) {
+    buffered[i] = turf.buffer(features[i], 10, {units: "meters"});
+    let bbox = turf.bbox(buffered[i]);
+    bboxes[i] = {
+        minX: bbox[0],
+        minY: bbox[1],
+        maxX: bbox[2],
+        maxY: bbox[3],
+        idx: i
+    }
+}
+tree.load(bboxes);
+
+for (let i = 0; i < features.length; i++) {
+    for (let match of tree.search(bboxes[i])) {
+        if (match.idx > i && !uf.inSameGroup(i, match.idx)) {
+            let intersects = false;
+            try {
+                let f1 = buffered[i], f2 = buffered[match.idx];
+
+                if (f1.geometry.type == "MultiPolygon" && f2.geometry.type == "Polygon") f2 = turf.multiPolygon([f2.geometry.coordinates]);
+                if (f2.geometry.type == "MultiPolygon" && f1.geometry.type == "Polygon") f1 = turf.multiPolygon([f1.geometry.coordinates]);
+
+                intersects = turf.booleanOverlap(f1, f2);
+            } catch(err) {
+                console.log("e1", err);
+                try {
+                    let f1 = features[i], f2 = features[match.idx];
+
+                    if (f1.geometry.type == "MultiLineString" && f2.geometry.type == "LineString") f2 = turf.multiLineString([f2.geometry.coordinates]);
+                    if (f2.geometry.type == "MultiLineString" && f1.geometry.type == "LineString") f1 = turf.multiLineString([f1.geometry.coordinates]);
+
+                    intersects = turf.booleanOverlap(f1, f2);
+                } catch(err2) { console.log("e2", err2); }
+            }
+
+            if (intersects) {
+                uf.union(i, match.idx);
+                console.log(i, match.idx);
+            }
+        }
+    }
+}
+
+let lengths = new Map();
+let colors = new Map();
+
+for (let i = 0; i < features.length; i++) {
+    let cluster = uf.find(i).getGroupLeader();
+    features[i].properties.cluster = cluster;
+    let existing = lengths.has(cluster) ? lengths.get(cluster) : 0;
+    lengths.set(cluster, existing + turf.length(features[i]), {units: 'miles'});
+}
+
+for (let i = 0; i < features.length; i++) {
+    let cluster = features[i].properties.cluster
+    let color = colors.has(cluster) ?
+        colors.get(cluster) :
+        colors.set(cluster, colorvert.hsl_to_hex(Math.floor(Math.random() * 360), 100, 25 + Math.random() * 25)).get(cluster);
+    features[i].properties.stroke = color;
+    features[i].properties.network_length = lengths.get(cluster);
+}
+
+let out = {
+    "type": "FeatureCollection",
+    "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+    "features": features
+}
+
+fs.writeFileSync("data/out.geojson", JSON.stringify(out, null, 4));
+//console.log(lengths);

--- a/scripts/lanes/convert.sh
+++ b/scripts/lanes/convert.sh
@@ -1,0 +1,2 @@
+ogr2ogr -t_srs EPSG:4326 -f GeoJSON data/Bike_Trails.geojson data/Bike_Trails/Bike_Trails.shp
+ogr2ogr -t_srs EPSG:4326 -f GeoJSON data/Bicycle_Lanes.geojson data/Bicycle_Lanes/Bicycle_Lanes.shp

--- a/scripts/lanes/package-lock.json
+++ b/scripts/lanes/package-lock.json
@@ -1,0 +1,1386 @@
+{
+  "name": "lanes",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@turf/along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
+      "integrity": "sha1-YdbmplhKzdq1asVYTge/jL5fi+s=",
+      "requires": {
+        "@turf/bearing": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/area": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
+      "integrity": "sha1-79iZv9Jgzb0VQbKjwVX4pdLu+h0=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/bbox": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
+      "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/bbox-clip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
+      "integrity": "sha1-M2S1Mo3/nzz0HZ4C7a/zdNFQzIQ=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "lineclip": "1.1.5"
+      }
+    },
+    "@turf/bbox-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
+      "integrity": "sha1-auuk7VHYXSluD3w4uIwznwHu4CQ=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
+      "integrity": "sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/bezier-spline": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
+      "integrity": "sha1-WaJ7ul17l+8Vqz/VpA+9I4cEm8o=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/boolean-clockwise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+      "integrity": "sha1-MwK32sYsXikaB4nimvcoM4f6nes=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/boolean-contains": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
+      "integrity": "sha1-WW1jruY2961T7pn5/yTJaZSg7xQ=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/boolean-point-on-line": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/boolean-crosses": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
+      "integrity": "sha1-Ab+uollvFk3kpNMlCU3HwlXHFdY=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/polygon-to-line": "5.1.5"
+      }
+    },
+    "@turf/boolean-disjoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.5.tgz",
+      "integrity": "sha1-MDzw2i52lGfmanRuXMRVOUw1gek=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/polygon-to-line": "5.1.5"
+      }
+    },
+    "@turf/boolean-equal": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
+      "integrity": "sha1-Kfj21gu4RQff12WzIlTbjnLJOKQ=",
+      "requires": {
+        "@turf/clean-coords": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "@turf/boolean-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
+      "integrity": "sha1-DU5kxSx3CijpPZ7834qLg3OsznU=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/line-overlap": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "@turf/boolean-parallel": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
+      "integrity": "sha1-c5NYR16ltlx+GCejw+DopofTqF0=",
+      "requires": {
+        "@turf/clean-coords": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/rhumb-bearing": "5.1.5"
+      }
+    },
+    "@turf/boolean-point-in-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
+      "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/boolean-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
+      "integrity": "sha1-9jPF/4Aq0ku48Vja269v9KAj3Xs=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/boolean-within": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
+      "integrity": "sha1-RxBdVtB1Kp0Pv81Dw2pfkUnchpc=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/boolean-point-on-line": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/buffer": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
+      "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/center": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/projection": "5.1.5",
+        "d3-geo": "1.7.1",
+        "turf-jsts": "1.2.2"
+      }
+    },
+    "@turf/center": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
+      "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/center-mean": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
+      "integrity": "sha1-jI6YdTkeXwnw5uePXWYbiLIQigo=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/center-median": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
+      "integrity": "sha1-u0Yb/noqSGAdikcnaFcYcjoUqHI=",
+      "requires": {
+        "@turf/center-mean": "5.1.5",
+        "@turf/centroid": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/center-of-mass": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
+      "integrity": "sha1-TTvXnYhJjbq4Mk1PafAyL2Uguco=",
+      "requires": {
+        "@turf/centroid": "5.1.5",
+        "@turf/convex": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/centroid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
+      "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
+      "integrity": "sha1-mxV3g1UIq1L7HBCypQZcuiuHtqU=",
+      "requires": {
+        "@turf/destination": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/clean-coords": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
+      "integrity": "sha1-EoAKmKeMmkUqcuxChJPEOs8q2h8=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/clone": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+      "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/clusters": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
+      "integrity": "sha1-ZzpeXxsZycq6vFfJCO6t1oIiTdQ=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/clusters-dbscan": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
+      "integrity": "sha1-V4H7TmVsdHoLjpk333MYHAMJ4m8=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "density-clustering": "1.3.0"
+      }
+    },
+    "@turf/clusters-kmeans": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
+      "integrity": "sha1-/W3+qLEzuovcI3CsPKzuFYejAvE=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "skmeans": "0.9.7"
+      }
+    },
+    "@turf/collect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
+      "integrity": "sha1-/pjJqMIY7PJP/DPXApUXt8GbKj4=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "rbush": "2.0.2"
+      }
+    },
+    "@turf/combine": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
+      "integrity": "sha1-uxS976VVBDVxlfwaEkzX1TqMiQU=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/concave": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
+      "integrity": "sha1-I7uqw4fQNLlldKG9cNBZI3qdIRA=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/tin": "5.1.5",
+        "topojson-client": "3.0.0",
+        "topojson-server": "3.0.0"
+      }
+    },
+    "@turf/convex": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
+      "integrity": "sha1-Dfk3fdACIWzpghsH9wXgN9rj4B0=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "concaveman": "1.1.1"
+      }
+    },
+    "@turf/destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
+      "integrity": "sha1-7TU4G9zoO73cvQei4rzivd/7zCY=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/difference": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
+      "integrity": "sha1-ok1pCnvKgD8QkKnuO52Qb8Q3H0I=",
+      "requires": {
+        "@turf/area": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "turf-jsts": "1.2.2"
+      }
+    },
+    "@turf/dissolve": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
+      "integrity": "sha1-LPEzqQIdIWODHD16lY1lB/nYGTg=",
+      "requires": {
+        "@turf/boolean-overlap": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/union": "5.1.5",
+        "geojson-rbush": "2.1.0",
+        "get-closest": "0.0.4"
+      }
+    },
+    "@turf/distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
+      "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
+      "integrity": "sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/rhumb-destination": "5.1.5",
+        "@turf/transform-rotate": "5.1.5"
+      }
+    },
+    "@turf/envelope": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
+      "integrity": "sha1-UBMwnFP91D369LWIplw/7X28EIo=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/bbox-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/explode": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
+      "integrity": "sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/flatten": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
+      "integrity": "sha1-2iknBnEz7WFpsLnWB7khVoiqE1g=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/flip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
+      "integrity": "sha1-Q29kOnIvDKU7n85jjkaT2zYIpoo=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/great-circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
+      "integrity": "sha1-3r+2cc5HVQnLY3MBwV/PzPo1mpM=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/helpers": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+      "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+    },
+    "@turf/hex-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
+      "integrity": "sha1-m3ul/s9QUfHoWJL3E/zlxVBQKmo=",
+      "requires": {
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/intersect": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/interpolate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
+      "integrity": "sha1-DxLwq3VtbdEK+ykMpuh3ve8BPqo=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/centroid": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/hex-grid": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/point-grid": "5.1.5",
+        "@turf/square-grid": "5.1.5",
+        "@turf/triangle-grid": "5.1.5"
+      }
+    },
+    "@turf/intersect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.5.tgz",
+      "integrity": "sha1-EhJh2vqEe1QI2CRfH1X9uy90S3o=",
+      "requires": {
+        "@turf/clean-coords": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/truncate": "5.1.5",
+        "turf-jsts": "1.2.2"
+      }
+    },
+    "@turf/invariant": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
+      "integrity": "sha1-9Z9P76CSJLFdzhZR+QPIaNV6JOE=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/isobands": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
+      "integrity": "sha1-a0TO9YTVUaMTBBh68jtKFYLj8I0=",
+      "requires": {
+        "@turf/area": "5.1.5",
+        "@turf/bbox": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/explode": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/isolines": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
+      "integrity": "sha1-irTn9Cuz38VGFOW/FVln9+VdLeE=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/kinks": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
+      "integrity": "sha1-irtpYdm7AQchO63fLCwmQNAlaYA=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/length": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
+      "integrity": "sha1-86X4ZMK5lqi7RxeUU1ofrxLuvvs=",
+      "requires": {
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/line-arc": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
+      "integrity": "sha1-AHinRHg1oSrkFKIR+aZNEYYVDhU=",
+      "requires": {
+        "@turf/circle": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/line-chunk": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
+      "integrity": "sha1-kQqFwFwG2dD5w4l3oF4IGNUIXEI=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/length": "5.1.5",
+        "@turf/line-slice-along": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/line-intersect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
+      "integrity": "sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "@turf/line-offset": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
+      "integrity": "sha1-KrWy8In4yRPiMdmUN4553KkLWh4=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/line-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
+      "integrity": "sha1-lDxvh6A4bcQ9+sEdKz/5wRLNP2A=",
+      "requires": {
+        "@turf/boolean-point-on-line": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/nearest-point-on-line": "5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "@turf/line-segment": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
+      "integrity": "sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/line-slice": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
+      "integrity": "sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/nearest-point-on-line": "5.1.5"
+      }
+    },
+    "@turf/line-slice-along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
+      "integrity": "sha1-7drQoh70efKWihG9LdcomiEy6aU=",
+      "requires": {
+        "@turf/bearing": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/line-split": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
+      "integrity": "sha1-Wy30w3YZty73JbUWPPmSbVVArLc=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/nearest-point-on-line": "5.1.5",
+        "@turf/square": "5.1.5",
+        "@turf/truncate": "5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "@turf/line-to-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
+      "integrity": "sha1-ITz0Gmj4Ikd4ujnTGH3sPouBhlo=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/mask": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
+      "integrity": "sha1-mrD+8aJyyY/j70kvn/thggayQtU=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/union": "5.1.5",
+        "rbush": "2.0.2"
+      }
+    },
+    "@turf/meta": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
+      "integrity": "sha1-wgqGPt7Qhp+yhUje6Ik0G8y0akY=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/midpoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
+      "integrity": "sha1-4mH2srDqgSTM7/VSomLdRlydBfA=",
+      "requires": {
+        "@turf/bearing": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/nearest-point": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
+      "integrity": "sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/nearest-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
+      "integrity": "sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=",
+      "requires": {
+        "@turf/bearing": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/nearest-point-to-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.5.tgz",
+      "integrity": "sha1-4Z5L52+3Dscu8e/OtQ71eqIRTGY=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/point-to-line-distance": "5.1.5"
+      }
+    },
+    "@turf/planepoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
+      "integrity": "sha1-GLvfAG91ne9eQsagBsn53oGyt/8=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/point-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
+      "integrity": "sha1-MFFBJI9Quv42zn5mukuX56sjaIc=",
+      "requires": {
+        "@turf/boolean-within": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/point-on-feature": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
+      "integrity": "sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/center": "5.1.5",
+        "@turf/explode": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/nearest-point": "5.1.5"
+      }
+    },
+    "@turf/point-to-line-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.5.tgz",
+      "integrity": "sha1-L+Vp3MmNERFlIqPJk75pXqwG+ik=",
+      "requires": {
+        "@turf/bearing": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/projection": "5.1.5",
+        "@turf/rhumb-bearing": "5.1.5",
+        "@turf/rhumb-distance": "5.1.5"
+      }
+    },
+    "@turf/points-within-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
+      "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/polygon-tangents": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
+      "integrity": "sha1-K/AJkUcwJbF44lDcfLmuVAm71lI=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/polygon-to-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
+      "integrity": "sha1-I7tEjYTcTGUZmaxhGjbZHFklA2o=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/polygonize": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
+      "integrity": "sha1-BJP6EYefOdELmtAs5qI+lC0IqjI=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/envelope": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/projection": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+      "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/random": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
+      "integrity": "sha1-sy78k0Vgroulfo67UfJBw5+6Lns=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/rewind": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+      "integrity": "sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=",
+      "requires": {
+        "@turf/boolean-clockwise": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/rhumb-destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
+      "integrity": "sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha1-GAaFdiX0IlOE2tQT5p85U4/192U=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/sample": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
+      "integrity": "sha1-6ctEikeJzFbuPeLdZ4HiNDQ1tBE=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/sector": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
+      "integrity": "sha1-rCu5TBPt1gNPb9wrZwCBNdIPXgc=",
+      "requires": {
+        "@turf/circle": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-arc": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/shortest-path": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
+      "integrity": "sha1-hUroCW9rw+EwD6ynfz6PZ9j5Nas=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/bbox-polygon": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/clean-coords": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/transform-scale": "5.1.5"
+      }
+    },
+    "@turf/simplify": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
+      "integrity": "sha1-Csjyei60IYGD7dmZjDJ1q+QIuSY=",
+      "requires": {
+        "@turf/clean-coords": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/square": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
+      "integrity": "sha1-qnsh5gM8ySUsOlvW89iNq9b+0YA=",
+      "requires": {
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/square-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
+      "integrity": "sha1-G9X3uesU8LYLwjH+/nNR0aMvGlE=",
+      "requires": {
+        "@turf/boolean-contains": "5.1.5",
+        "@turf/boolean-overlap": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/intersect": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/standard-deviational-ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
+      "integrity": "sha1-hc0oO14ayljyG9ZkEuQUtW2FIyQ=",
+      "requires": {
+        "@turf/center-mean": "5.1.5",
+        "@turf/ellipse": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/points-within-polygon": "5.1.5"
+      }
+    },
+    "@turf/tag": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
+      "integrity": "sha1-0e4aUIjs/UoUEQGcmCOczypJfSA=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/tesselate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
+      "integrity": "sha1-MqWU6cIaAEIKn5DSxD3z4RZgYc0=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "earcut": "2.1.3"
+      }
+    },
+    "@turf/tin": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
+      "integrity": "sha1-KCI+r8X76a6azKgc3P6l0UJMkX0=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/transform-rotate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
+      "integrity": "sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=",
+      "requires": {
+        "@turf/centroid": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/rhumb-bearing": "5.1.5",
+        "@turf/rhumb-destination": "5.1.5",
+        "@turf/rhumb-distance": "5.1.5"
+      }
+    },
+    "@turf/transform-scale": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
+      "integrity": "sha1-cP064BhWz3uunxWtVhzf6PiQAbk=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/center": "5.1.5",
+        "@turf/centroid": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/rhumb-bearing": "5.1.5",
+        "@turf/rhumb-destination": "5.1.5",
+        "@turf/rhumb-distance": "5.1.5"
+      }
+    },
+    "@turf/transform-translate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
+      "integrity": "sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/rhumb-destination": "5.1.5"
+      }
+    },
+    "@turf/triangle-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
+      "integrity": "sha1-ezZ2IQhVTBTyjK/zxIsc/ILI3IE=",
+      "requires": {
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/intersect": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/truncate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
+      "integrity": "sha1-nu37Oxi6gfLJjT6tCUMcyhiErYk=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/turf": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
+      "integrity": "sha1-wxIlkoh+0jS3VGi4qMRb+Ib7+PY=",
+      "requires": {
+        "@turf/along": "5.1.5",
+        "@turf/area": "5.1.5",
+        "@turf/bbox": "5.1.5",
+        "@turf/bbox-clip": "5.1.5",
+        "@turf/bbox-polygon": "5.1.5",
+        "@turf/bearing": "5.1.5",
+        "@turf/bezier-spline": "5.1.5",
+        "@turf/boolean-clockwise": "5.1.5",
+        "@turf/boolean-contains": "5.1.5",
+        "@turf/boolean-crosses": "5.1.5",
+        "@turf/boolean-disjoint": "5.1.5",
+        "@turf/boolean-equal": "5.1.5",
+        "@turf/boolean-overlap": "5.1.5",
+        "@turf/boolean-parallel": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/boolean-point-on-line": "5.1.5",
+        "@turf/boolean-within": "5.1.5",
+        "@turf/buffer": "5.1.5",
+        "@turf/center": "5.1.5",
+        "@turf/center-mean": "5.1.5",
+        "@turf/center-median": "5.1.5",
+        "@turf/center-of-mass": "5.1.5",
+        "@turf/centroid": "5.1.5",
+        "@turf/circle": "5.1.5",
+        "@turf/clean-coords": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/clusters": "5.1.5",
+        "@turf/clusters-dbscan": "5.1.5",
+        "@turf/clusters-kmeans": "5.1.5",
+        "@turf/collect": "5.1.5",
+        "@turf/combine": "5.1.5",
+        "@turf/concave": "5.1.5",
+        "@turf/convex": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/difference": "5.1.5",
+        "@turf/dissolve": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/ellipse": "5.1.5",
+        "@turf/envelope": "5.1.5",
+        "@turf/explode": "5.1.5",
+        "@turf/flatten": "5.1.5",
+        "@turf/flip": "5.1.5",
+        "@turf/great-circle": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/hex-grid": "5.1.5",
+        "@turf/interpolate": "5.1.5",
+        "@turf/intersect": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/isobands": "5.1.5",
+        "@turf/isolines": "5.1.5",
+        "@turf/kinks": "5.1.5",
+        "@turf/length": "5.1.5",
+        "@turf/line-arc": "5.1.5",
+        "@turf/line-chunk": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/line-offset": "5.1.5",
+        "@turf/line-overlap": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/line-slice": "5.1.5",
+        "@turf/line-slice-along": "5.1.5",
+        "@turf/line-split": "5.1.5",
+        "@turf/line-to-polygon": "5.1.5",
+        "@turf/mask": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/midpoint": "5.1.5",
+        "@turf/nearest-point": "5.1.5",
+        "@turf/nearest-point-on-line": "5.1.5",
+        "@turf/nearest-point-to-line": "5.1.5",
+        "@turf/planepoint": "5.1.5",
+        "@turf/point-grid": "5.1.5",
+        "@turf/point-on-feature": "5.1.5",
+        "@turf/point-to-line-distance": "5.1.5",
+        "@turf/points-within-polygon": "5.1.5",
+        "@turf/polygon-tangents": "5.1.5",
+        "@turf/polygon-to-line": "5.1.5",
+        "@turf/polygonize": "5.1.5",
+        "@turf/projection": "5.1.5",
+        "@turf/random": "5.1.5",
+        "@turf/rewind": "5.1.5",
+        "@turf/rhumb-bearing": "5.1.5",
+        "@turf/rhumb-destination": "5.1.5",
+        "@turf/rhumb-distance": "5.1.5",
+        "@turf/sample": "5.1.5",
+        "@turf/sector": "5.1.5",
+        "@turf/shortest-path": "5.1.5",
+        "@turf/simplify": "5.1.5",
+        "@turf/square": "5.1.5",
+        "@turf/square-grid": "5.1.5",
+        "@turf/standard-deviational-ellipse": "5.1.5",
+        "@turf/tag": "5.1.5",
+        "@turf/tesselate": "5.1.5",
+        "@turf/tin": "5.1.5",
+        "@turf/transform-rotate": "5.1.5",
+        "@turf/transform-scale": "5.1.5",
+        "@turf/transform-translate": "5.1.5",
+        "@turf/triangle-grid": "5.1.5",
+        "@turf/truncate": "5.1.5",
+        "@turf/union": "5.1.5",
+        "@turf/unkink-polygon": "5.1.5",
+        "@turf/voronoi": "5.1.5"
+      }
+    },
+    "@turf/union": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
+      "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "turf-jsts": "1.2.2"
+      }
+    },
+    "@turf/unkink-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
+      "integrity": "sha1-ewGEfFD7V0riV54Z5Ey6hSbSE8M=",
+      "requires": {
+        "@turf/area": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "rbush": "2.0.2"
+      }
+    },
+    "@turf/voronoi": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
+      "integrity": "sha1-6FbpQG3MLyXWbdyJhYTifC6/ymY=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "d3-voronoi": "1.1.2"
+      }
+    },
+    "colorvert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/colorvert/-/colorvert-0.2.1.tgz",
+      "integrity": "sha1-r/6/y0sg12Bm6pU/JpRbx9NbfB8=",
+      "requires": {
+        "transicc": "1.2.1"
+      }
+    },
+    "commander": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+    },
+    "concaveman": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.1.1.tgz",
+      "integrity": "sha1-bCSCWAslI874L8K+wAoEFebmgWI=",
+      "requires": {
+        "monotone-convex-hull-2d": "1.0.1",
+        "point-in-polygon": "1.0.1",
+        "rbush": "2.0.2",
+        "robust-orientation": "1.1.3",
+        "tinyqueue": "1.2.3"
+      }
+    },
+    "d3-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
+      "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
+    },
+    "d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "requires": {
+        "d3-array": "1.2.1"
+      }
+    },
+    "d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
+    "density-clustering": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
+      "integrity": "sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU="
+    },
+    "earcut": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.3.tgz",
+      "integrity": "sha512-AxdCdWUk1zzK/NuZ7e1ljj6IGC+VAdC3Qb7QQDsXpfNrc5IM8tL9nNXUmEGE6jRHTfZ10zhzRhtDmWVsR5pd3A=="
+    },
+    "geojson-equality": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
+      "integrity": "sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=",
+      "requires": {
+        "deep-equal": "1.0.1"
+      }
+    },
+    "geojson-rbush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
+      "integrity": "sha1-O9c745H8ELCuaT2bis6iquC4Oo0=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "rbush": "2.0.2"
+      }
+    },
+    "get-closest": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
+      "integrity": "sha1-JprHdtHmAiqg/Vht1wjop9Miaa8="
+    },
+    "lineclip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
+      "integrity": "sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM="
+    },
+    "monotone-convex-hull-2d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
+      "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
+      "requires": {
+        "robust-orientation": "1.1.3"
+      }
+    },
+    "node-union-find": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/node-union-find/-/node-union-find-0.0.3.tgz",
+      "integrity": "sha1-+Sg1mZHBRpI2vghQsz6KdMxNXrQ="
+    },
+    "point-in-polygon": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.0.1.tgz",
+      "integrity": "sha1-1Ztk6P7kHElFiqyCtWcYxZV7Kvc="
+    },
+    "quickselect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.0.1.tgz",
+      "integrity": "sha512-Jt30UQSzTbxf6L2bFTMabHtGtYUzQcvOY0a+s5brm8tzndV/XWifBIH9v5QKtH5gGCZ5RRDwRhdhGMDVHAEGNQ=="
+    },
+    "rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "requires": {
+        "quickselect": "1.0.1"
+      }
+    },
+    "robust-orientation": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
+      "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
+      "requires": {
+        "robust-scale": "1.0.2",
+        "robust-subtract": "1.0.0",
+        "robust-sum": "1.0.0",
+        "two-product": "1.0.2"
+      }
+    },
+    "robust-scale": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
+      "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+      "requires": {
+        "two-product": "1.0.2",
+        "two-sum": "1.0.0"
+      }
+    },
+    "robust-subtract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
+      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
+    },
+    "robust-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
+      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
+    },
+    "skmeans": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
+      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg=="
+    },
+    "tinyqueue": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
+      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
+    },
+    "topojson-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.0.0.tgz",
+      "integrity": "sha1-H5kpOnfvQqRI0DKoGqmCtz82DS8=",
+      "requires": {
+        "commander": "2.13.0"
+      }
+    },
+    "topojson-server": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.0.tgz",
+      "integrity": "sha1-N4546Hw5cqe1vixdYENptrrmnF4=",
+      "requires": {
+        "commander": "2.13.0"
+      }
+    },
+    "transicc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/transicc/-/transicc-1.2.1.tgz",
+      "integrity": "sha1-J4pQ8eN1VY0FbaF8Yj13++0K84Y="
+    },
+    "turf-jsts": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.2.tgz",
+      "integrity": "sha1-uZkjZZpGc3uBQT7P+b1w42C6F1M="
+    },
+    "two-product": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
+      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
+    },
+    "two-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
+      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
+    }
+  }
+}

--- a/scripts/lanes/package.json
+++ b/scripts/lanes/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "lanes",
+  "version": "0.0.1",
+  "description": "",
+  "main": "cluster.js",
+  "dependencies": {
+    "colorvert": "^0.2.1",
+    "node-union-find": "^0.0.3",
+    "rbush": "^2.0.1",
+    "@turf/turf": "^5.1.6"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
This script takes in the bike lane and bike trail data, and identifies connected subgraphs of that network to answer the "what sized-networks are connected" question. It outputs a geojson that has all the lanes and trails, but with each feature augmented with a cluster ID (not informative except that it will be the same for all features within the same cluster) and the combined total length of all the segments in the cluster. The idea is that if someone draws a new line, you should be able to check which existing features it intersects with, and if they're not from the same cluster, you can figure out "hey, it's connecting a segment from cluster 12 of total length ten miles and cluster 34 of total length one mile." Connectedness, for my purposes, is either that the segments intersect, or come within 20 meters of intersecting (strictly speaking, if two segments each buffered out by ten meters touch). We could maybe be more strict about this but it seems to produce okay results.

Overall almost all bike lanes and trails end up as part of a single, 187-mile-long cluster, so I'm kind of skeptical of the utility of this feature. Still, it's here if we want it.

![lanes](https://user-images.githubusercontent.com/78930/35009642-348ba448-face-11e7-9234-e00150f8ba20.png)

Here's the output: https://transfer.sh/ug3jK/networked_bikelanes.geojson