### PR TITLE
Adds info table

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,3 +6,85 @@ var map = new mapboxgl.Map({
     center: [-77.007945, 38.896870],
     zoom: 12
 });
+
+var draw = new MapboxDraw({
+    controls: {
+        point: false,
+        polygon: false
+    }
+});
+
+map.addControl(draw);
+
+map.on('load', function() {
+
+// Since we are planning to also visualize the corridor data on the map, it's probably
+// easiest to reuse the vector tiles for data querying.
+
+// TODO: filter these crash queries to only include 2016 and later
+// However, the `REPORTDATE` field contains string values, not numbers, so we may want to reformat these first
+// although it would make data updates easier if we didn't reformat it...
+
+	var corridorInfo = [
+		{
+			id: 'crashes-total',
+			text: 'total crashes',
+			data: turf.featureCollection(map.querySourceFeatures('composite', {
+				sourceLayer: 'Crashes_in_DC-d0weq7'
+				}))
+		},
+		{
+			id: 'crashes-cyclists',
+			text: 'bike-related crashes',
+			data: turf.featureCollection(map.querySourceFeatures('composite', {
+				sourceLayer: 'Crashes_in_DC-d0weq7',
+				filter: ['>', 'TOTAL_BICY', 0]
+				}))
+		},
+		{
+			id: 'crashes-pedestrians',
+			text: 'pedestrian-related crashes',
+			data: turf.featureCollection(map.querySourceFeatures('composite', {
+				sourceLayer: 'Crashes_in_DC-d0weq7',
+				filter: ['>', 'TOTAL_PEDE', 0]
+				}))
+		}
+	];
+
+	map.on('draw.create', updateCorridor);
+	map.on('draw.delete', updateCorridor);
+	map.on('draw.update', updateCorridor);
+
+	function updateCorridor(e) {
+		var corridor = draw.getAll();
+		// Currently, this allows you to draw multiple unconnected lines as a "corridor"
+		var bufferedCorridor = turf.buffer(corridor, 10, {units: 'meters'});
+		for (var i = 0; i < corridorInfo.length; i++) {
+			// var data will need to be assigned differently depending on the source
+			// current implementation only works for points
+			var data = turf.pointsWithinPolygon(corridorInfo[i].data, bufferedCorridor).features.length;
+			// Creates new rows in the table the first time a line is drawn
+			// Replaces old data each time a new line is drawn
+			// (There's probably better ways to update the table):
+			if (document.getElementById('corridor-info-table').rows.length > i) {
+				var row = document.getElementById(corridorInfo[i].id);
+				var desc = row.cells[0];
+				var more = row.cells[1];
+			} else {
+				var row = document.getElementById('corridor-info-table').insertRow(-1);
+				row.id = corridorInfo[i].id;
+				console.log(row.id);
+				var desc = row.insertCell(0);
+				var more = row.insertCell(1);
+			};
+			desc.innerHTML =  '<span class="txt-bold">' + data + '</span> ' + corridorInfo[i].text;
+			// "More" section is a placeholder for accessing:
+			// 1. Information about the data the statistic was derived from 
+			// (we could also consolidate all the data info in one place elsewhere)
+			// 2. Toggling on/off visualizations on the map for that statistic
+			more.innerHTML = '<svg class="icon inline"><use xlink:href="#icon-question"/></svg> <svg class="icon inline"><use xlink:href="#icon-map"/></svg>'
+		};
+		document.getElementById('corridor-info').style.visibility = 'visible';
+	}
+});
+

--- a/draw_plugin.js
+++ b/draw_plugin.js
@@ -1,3 +1,0 @@
-var Draw = new MapboxDraw();
-
-map.addControl(Draw)

--- a/index.html
+++ b/index.html
@@ -6,18 +6,41 @@
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
     <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.42.2/mapbox-gl.js'></script>
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.42.2/mapbox-gl.css' rel='stylesheet' />
-    <script src='https://api.tiles.mapbox.com/mapbox.js/plugins/turf/v3.0.11/turf.min.js'></script>
-    <script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.0.0/mapbox-gl-draw.js'></script>
-    <link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.0.0/mapbox-gl-draw.css' type='text/css'/>
+    <script src='https://npmcdn.com/@turf/turf/turf.min.js'></script>
+    <script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.0.4/mapbox-gl-draw.js'></script>
+    <link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.0.4/mapbox-gl-draw.css' type='text/css'/>
+    <link href="https://api.mapbox.com/mapbox-assembly/v0.20.0/assembly.min.css" rel="stylesheet">
+    <script async defer src="https://api.mapbox.com/mapbox-assembly/v0.20.0/assembly.js"></script>
     <link rel='stylesheet' href='style.css'>
     </head>
 </head>
 
 <body>
 
+<div class='viewport-full relative scroll-hidden'>
+  <div class='bg-darken10 viewport-twothirds viewport-full-ml absolute top left right bottom'></div>
+  <div class='absolute top-ml left bottom z1 w-full w360-ml px12 py12-ml'>
+    <div class='flex-parent flex-parent--column viewport-third h-auto-ml hmax-full bg-white round-ml shadow-darken10'>
+      <div class='px12 py12 scroll-auto'>
+        <h3 class='txt-m txt-bold mb6'>Add a bike lane</h3>
+        <p>Use the controls in the sidepanel to draw a bike lane on the map. Double-click the end point to "add" your bike lane.</p>
+        <div id='corridor-info' class='mt12'>
+          <p>On this corridor, there have been:</p>
+          <table id='corridor-info-table' class='table mt12'>
+          </table>
+      </div>  
+      </div>
+      <div>
+      <footer class='px12 py12 bg-gray-faint round-b-ml txt-s'>
+        Footer content here
+      </footer>
+    </div>
+  </div>
+</div>
+
 <div id='map'></div>
+
 <script src='app.js' type='text/javascript'></script>
-<script src='draw_plugin.js'></script>
 
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,2 +1,11 @@
 body { margin:0; padding:0; }
 #map { position:absolute; top:0; bottom:0; width:100%; }
+#corridor-info { visibility:hidden; }
+.table { 
+	border-style: none;
+	border-collapse: collapse;
+}
+.table td, th { 
+	border-style: none; 
+	padding: 6px;
+}


### PR DESCRIPTION
- Creates an array of data objects that will correspond to [each item in the info table](https://github.com/mapbox/waba-add-a-bike-lane/issues/1#issuecomment-349805426). So far this only includes the first 3 items (crash data).

- Takes all the draw data, creates a buffer, and calculates how many crashes fall within the buffer (this workflow works in general for counting points, but we'll need a different flow for some of the other data). 

- Outputs crash information to a table. 

- Updates info table when lines are edited, created, or deleted.

@joegomez88 @apendleton @k-mahoney This is really rough, but it would be great if we could have a minimal working demo up as soon as possible, based on what we outlined [here](https://github.com/mapbox/waba-add-a-bike-lane/issues/5#issuecomment-349806251). Please take a look at this PR if you get a chance! if there's anything glaringly bad/inefficient feel free to update in this PR, otherwise we can clean it up later.

The main missing piece is a way to save the information – either a copy function for the info table, or a permalink. I'll open tickets for those features.