### PR TITLE
Add remaining data to corridor info display

### DIFF
--- a/add-bike-lane-style.json
+++ b/add-bike-lane-style.json
@@ -1,0 +1,4129 @@
+{
+    "version": 8,
+    "name": "WABA bike lanes placeholder",
+    "metadata": {
+        "mapbox:autocomposite": true,
+        "mapbox:type": "default",
+        "mapbox:origin": "light-v9",
+        "mapbox:groups": {
+            "1444934828655.3389": {"name": "Aeroways", "collapsed": true},
+            "1444933322393.2852": {
+                "name": "POI labels  (scalerank 1)",
+                "collapsed": true
+            },
+            "1444855786460.0557": {"name": "Roads", "collapsed": false},
+            "1444934295202.7542": {
+                "name": "Admin boundaries",
+                "collapsed": true
+            },
+            "1444856151690.9143": {"name": "State labels", "collapsed": true},
+            "1444933721429.3076": {"name": "Road labels", "collapsed": false},
+            "1444933358918.2366": {
+                "name": "POI labels (scalerank 2)",
+                "collapsed": false
+            },
+            "1444933808272.805": {"name": "Water labels", "collapsed": true},
+            "1444933372896.5967": {
+                "name": "POI labels (scalerank 3)",
+                "collapsed": false
+            },
+            "1444855799204.86": {"name": "Bridges", "collapsed": true},
+            "1444856087950.3635": {"name": "Marine labels", "collapsed": true},
+            "1456969573402.7817": {"name": "Hillshading", "collapsed": true},
+            "1444862510685.128": {"name": "City labels", "collapsed": true},
+            "1444855769305.6016": {"name": "Tunnels", "collapsed": true},
+            "1456970288113.8113": {"name": "Landcover", "collapsed": true},
+            "1444856144497.7825": {"name": "Country labels", "collapsed": true}
+        }
+    },
+    "center": [-77.01954141224155, 38.913732215826826],
+    "zoom": 12.931559240489872,
+    "bearing": 0,
+    "pitch": 0,
+    "sources": {
+        "composite": {
+            "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,nicki.daq6vzck,nicki.382btzl6,k-mahoney.9p18idhz",
+            "type": "vector"
+        }
+    },
+    "sprite": "mapbox://sprites/nicki/cjav7yuqylrmk2speysk7tz9y",
+    "glyphs": "mapbox://fonts/nicki/{fontstack}/{range}.pbf",
+    "layers": [
+        {
+            "id": "background",
+            "type": "background",
+            "layout": {},
+            "paint": {"background-color": "hsl(55, 11%, 96%)"}
+        },
+        {
+            "id": "landcover_wood",
+            "type": "fill",
+            "metadata": {"mapbox:group": "1456970288113.8113"},
+            "source": "composite",
+            "source-layer": "landcover",
+            "maxzoom": 14,
+            "filter": ["==", "class", "wood"],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 89%)",
+                "fill-opacity": 0.1,
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "landcover_scrub",
+            "type": "fill",
+            "metadata": {"mapbox:group": "1456970288113.8113"},
+            "source": "composite",
+            "source-layer": "landcover",
+            "maxzoom": 14,
+            "filter": ["==", "class", "scrub"],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 89%)",
+                "fill-opacity": 0.1,
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "landcover_grass",
+            "type": "fill",
+            "metadata": {"mapbox:group": "1456970288113.8113"},
+            "source": "composite",
+            "source-layer": "landcover",
+            "maxzoom": 14,
+            "filter": ["==", "class", "grass"],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 89%)",
+                "fill-opacity": 0.1,
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "landcover_crop",
+            "type": "fill",
+            "metadata": {"mapbox:group": "1456970288113.8113"},
+            "source": "composite",
+            "source-layer": "landcover",
+            "maxzoom": 14,
+            "filter": ["==", "class", "crop"],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 89%)",
+                "fill-opacity": 0.1,
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "national_park",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "landuse_overlay",
+            "filter": ["==", "class", "national_park"],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(150, 6%, 93%)",
+                "fill-opacity": {"base": 1, "stops": [[5, 0], [6, 0.5]]}
+            }
+        },
+        {
+            "id": "parks",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "landuse",
+            "filter": ["==", "class", "park"],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(150, 6%, 93%)",
+                "fill-opacity": {"base": 1, "stops": [[5, 0], [6, 0.75]]}
+            }
+        },
+        {
+            "id": "pitch",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "landuse",
+            "filter": ["==", "class", "pitch"],
+            "layout": {},
+            "paint": {"fill-color": "hsl(150, 6%, 93%)"}
+        },
+        {
+            "id": "industrial",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "landuse",
+            "filter": ["==", "class", "industrial"],
+            "layout": {},
+            "paint": {"fill-color": "hsl(150, 6%, 93%)"}
+        },
+        {
+            "id": "sand",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "landuse",
+            "filter": ["==", "class", "sand"],
+            "layout": {},
+            "paint": {"fill-color": "hsl(150, 6%, 93%)"}
+        },
+        {
+            "id": "hillshade_highlight_bright",
+            "type": "fill",
+            "metadata": {"mapbox:group": "1456969573402.7817"},
+            "source": "composite",
+            "source-layer": "hillshade",
+            "maxzoom": 16,
+            "filter": ["==", "level", 94],
+            "layout": {},
+            "paint": {
+                "fill-color": "#fff",
+                "fill-opacity": {"stops": [[14, 0.08], [16, 0]]},
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "hillshade_highlight_med",
+            "type": "fill",
+            "metadata": {"mapbox:group": "1456969573402.7817"},
+            "source": "composite",
+            "source-layer": "hillshade",
+            "maxzoom": 16,
+            "filter": ["==", "level", 90],
+            "layout": {},
+            "paint": {
+                "fill-color": "#fff",
+                "fill-opacity": {"stops": [[14, 0.08], [16, 0]]},
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "hillshade_shadow_faint",
+            "type": "fill",
+            "metadata": {"mapbox:group": "1456969573402.7817"},
+            "source": "composite",
+            "source-layer": "hillshade",
+            "maxzoom": 16,
+            "filter": ["==", "level", 89],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 35%)",
+                "fill-opacity": {"stops": [[14, 0.033], [16, 0]]},
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "hillshade_shadow_med",
+            "type": "fill",
+            "metadata": {"mapbox:group": "1456969573402.7817"},
+            "source": "composite",
+            "source-layer": "hillshade",
+            "maxzoom": 16,
+            "filter": ["==", "level", 78],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 35%)",
+                "fill-opacity": {"stops": [[14, 0.033], [16, 0]]},
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "hillshade_shadow_dark",
+            "type": "fill",
+            "metadata": {"mapbox:group": "1456969573402.7817"},
+            "source": "composite",
+            "source-layer": "hillshade",
+            "maxzoom": 16,
+            "filter": ["==", "level", 67],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 35%)",
+                "fill-opacity": {"stops": [[14, 0.06], [16, 0]]},
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "hillshade_shadow_extreme",
+            "type": "fill",
+            "metadata": {"mapbox:group": "1456969573402.7817"},
+            "source": "composite",
+            "source-layer": "hillshade",
+            "maxzoom": 16,
+            "filter": ["==", "level", 56],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 35%)",
+                "fill-opacity": {"stops": [[14, 0.06], [16, 0]]},
+                "fill-antialias": false
+            }
+        },
+        {
+            "id": "waterway-river-canal",
+            "type": "line",
+            "source": "composite",
+            "source-layer": "waterway",
+            "minzoom": 8,
+            "filter": [
+                "any",
+                ["==", "class", "canal"],
+                ["==", "class", "river"]
+            ],
+            "layout": {
+                "line-cap": {"base": 1, "stops": [[0, "butt"], [11, "round"]]},
+                "line-join": "round"
+            },
+            "paint": {
+                "line-color": "#cbd3d4",
+                "line-width": {"base": 1.3, "stops": [[8.5, 0.1], [20, 8]]},
+                "line-opacity": {"base": 1, "stops": [[8, 0], [8.5, 1]]}
+            }
+        },
+        {
+            "id": "water shadow",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "water",
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(185, 7%, 73%)",
+                "fill-translate": {
+                    "base": 1.2,
+                    "stops": [[7, [0, 0]], [16, [-1, -1]]]
+                },
+                "fill-translate-anchor": "viewport",
+                "fill-opacity": 1
+            }
+        },
+        {
+            "id": "water",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "water",
+            "layout": {},
+            "paint": {"fill-color": "hsl(185, 9%, 81%)"}
+        },
+        {
+            "id": "barrier_line-land-polygon",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "barrier_line",
+            "filter": [
+                "all",
+                ["==", "$type", "Polygon"],
+                ["==", "class", "land"]
+            ],
+            "layout": {},
+            "paint": {"fill-color": "#f0f5f3"}
+        },
+        {
+            "id": "barrier_line-land-line",
+            "type": "line",
+            "source": "composite",
+            "source-layer": "barrier_line",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                ["==", "class", "land"]
+            ],
+            "layout": {"line-cap": "round"},
+            "paint": {
+                "line-width": {"base": 1.99, "stops": [[14, 0.75], [20, 40]]},
+                "line-color": "#f0f5f3"
+            }
+        },
+        {
+            "id": "aeroway-polygon",
+            "type": "fill",
+            "metadata": {"mapbox:group": "1444934828655.3389"},
+            "source": "composite",
+            "source-layer": "aeroway",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["!=", "type", "apron"],
+                ["==", "$type", "Polygon"]
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(0, 0%, 97%)",
+                "fill-opacity": {"base": 1, "stops": [[11, 0], [11.5, 1]]}
+            }
+        },
+        {
+            "id": "aeroway-runway",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444934828655.3389"},
+            "source": "composite",
+            "source-layer": "aeroway",
+            "minzoom": 9,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                ["==", "type", "runway"]
+            ],
+            "layout": {},
+            "paint": {
+                "line-color": "hsl(0, 0%, 95%)",
+                "line-width": {"base": 1.5, "stops": [[9, 1], [18, 80]]}
+            }
+        },
+        {
+            "id": "aeroway-taxiway",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444934828655.3389"},
+            "source": "composite",
+            "source-layer": "aeroway",
+            "minzoom": 9,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                ["==", "type", "taxiway"]
+            ],
+            "layout": {},
+            "paint": {
+                "line-color": "hsl(0, 0%, 95%)",
+                "line-width": {"base": 1.5, "stops": [[10, 0.5], [18, 20]]}
+            }
+        },
+        {
+            "id": "building",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "building",
+            "minzoom": 15,
+            "filter": [
+                "all",
+                ["!=", "type", "building:part"],
+                ["==", "underground", "false"]
+            ],
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(55, 5%, 91%)",
+                "fill-opacity": {"base": 1, "stops": [[15.5, 0], [16, 1]]},
+                "fill-outline-color": "hsl(55, 3%, 87%)"
+            }
+        },
+        {
+            "id": "tunnel-street-low",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": {
+                    "stops": [[11.5, 0], [12, 1], [14, 1], [14.01, 0]]
+                }
+            }
+        },
+        {
+            "id": "tunnel-street_limited-low",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": {
+                    "stops": [[11.5, 0], [12, 1], [14, 1], [14.01, 0]]
+                }
+            }
+        },
+        {
+            "id": "tunnel-service-link-track-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!=", "type", "trunk_link"],
+                    ["==", "structure", "tunnel"],
+                    ["in", "class", "link", "service", "track"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
+                "line-dasharray": [3, 3]
+            }
+        },
+        {
+            "id": "tunnel-street_limited-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[13, 0], [14, 2], [18, 18]]
+                },
+                "line-dasharray": [3, 3],
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
+        },
+        {
+            "id": "tunnel-street-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[13, 0], [14, 2], [18, 18]]
+                },
+                "line-dasharray": [3, 3],
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
+        },
+        {
+            "id": "tunnel-secondary-tertiary-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "structure", "tunnel"],
+                    ["in", "class", "secondary", "tertiary"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.2, "stops": [[10, 0.75], [18, 2]]},
+                "line-dasharray": [3, 3],
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[8.5, 0.5], [10, 0.75], [18, 26]]
+                },
+                "line-color": "hsl(185, 12%, 89%)"
+            }
+        },
+        {
+            "id": "tunnel-primary-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "primary"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [16, 2]]},
+                "line-dasharray": [3, 3],
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-color": "hsl(185, 12%, 89%)"
+            }
+        },
+        {
+            "id": "tunnel-trunk_link-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "structure", "tunnel"],
+                    ["==", "type", "trunk_link"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-dasharray": [3, 3]
+            }
+        },
+        {
+            "id": "tunnel-motorway_link-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "motorway_link"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-dasharray": [3, 3]
+            }
+        },
+        {
+            "id": "tunnel-trunk-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                ["all", ["==", "structure", "tunnel"], ["==", "type", "trunk"]]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [16, 2]]},
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-opacity": 1,
+                "line-dasharray": [3, 3]
+            }
+        },
+        {
+            "id": "tunnel-motorway-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "motorway"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [16, 2]]},
+                "line-color": "hsl(185, 12%, 89%)",
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-opacity": 1,
+                "line-dasharray": [3, 3]
+            }
+        },
+        {
+            "id": "tunnel-construction",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "construction"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-join": "miter"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]},
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [14, [0.4, 0.8]],
+                        [15, [0.3, 0.6]],
+                        [16, [0.2, 0.3]],
+                        [17, [0.2, 0.25]],
+                        [18, [0.15, 0.15]]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "tunnel-path",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!=", "type", "steps"],
+                    ["==", "class", "path"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[15, 1], [18, 4]]},
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [1, 0.5]]
+                    ]
+                },
+                "line-color": "hsl(0, 0%, 85%)",
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 1]]}
+            }
+        },
+        {
+            "id": "tunnel-steps",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                ["all", ["==", "structure", "tunnel"], ["==", "type", "steps"]]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[15, 1], [18, 4]]},
+                "line-color": "hsl(0, 0%, 85%)",
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [0.3, 0.3]]
+                    ]
+                },
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 1]]}
+            }
+        },
+        {
+            "id": "tunnel-trunk_link",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "structure", "tunnel"],
+                    ["==", "type", "trunk_link"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": 1,
+                "line-dasharray": [1, 0]
+            }
+        },
+        {
+            "id": "tunnel-motorway_link",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "motorway_link"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": 1,
+                "line-dasharray": [1, 0]
+            }
+        },
+        {
+            "id": "tunnel-pedestrian",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "pedestrian"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": 1,
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [[14, [1, 0]], [15, [1.5, 0.4]], [16, [1, 0.2]]]
+                }
+            }
+        },
+        {
+            "id": "tunnel-service-link-track",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!=", "type", "trunk_link"],
+                    ["==", "structure", "tunnel"],
+                    ["in", "class", "link", "service", "track"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-dasharray": [1, 0]
+            }
+        },
+        {
+            "id": "tunnel-street_limited",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
+        },
+        {
+            "id": "tunnel-street",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
+        },
+        {
+            "id": "tunnel-secondary-tertiary",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "structure", "tunnel"],
+                    ["in", "class", "secondary", "tertiary"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[8.5, 0.5], [10, 0.75], [18, 26]]
+                },
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": 1,
+                "line-dasharray": [1, 0],
+                "line-blur": 0
+            }
+        },
+        {
+            "id": "tunnel-primary",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "primary"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-opacity": 1,
+                "line-dasharray": [1, 0],
+                "line-blur": 0
+            }
+        },
+        {
+            "id": "tunnel-trunk",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                ["all", ["==", "class", "trunk"], ["==", "structure", "tunnel"]]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-color": "hsl(187, 7%, 88%)"
+            }
+        },
+        {
+            "id": "tunnel-motorway",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855769305.6016"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "motorway"],
+                    ["==", "structure", "tunnel"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-dasharray": [1, 0],
+                "line-opacity": 1,
+                "line-color": "hsl(187, 7%, 88%)",
+                "line-blur": 0
+            }
+        },
+        {
+            "id": "road-pedestrian-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 12,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "pedestrian"],
+                    ["==", "structure", "none"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[14, 2], [18, 14.5]]},
+                "line-color": {
+                    "base": 1,
+                    "stops": [[9, "hsl(156, 7%, 87%)"], [11, "#e8edeb"]]
+                },
+                "line-gap-width": 0,
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [[6, 0], [7, 0.4], [9, 0.5], [10, 1]]
+                }
+            }
+        },
+        {
+            "id": "road-street-low",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                ["all", ["==", "class", "street"], ["==", "structure", "none"]]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "stops": [[11, 0], [11.25, 1], [14, 1], [14.01, 0]]
+                }
+            }
+        },
+        {
+            "id": "road-street_limited-low",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "none"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "stops": [[11, 0], [11.25, 1], [14, 1], [14.01, 0]]
+                }
+            }
+        },
+        {
+            "id": "road-service-link-track-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!=", "type", "trunk_link"],
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "class", "link", "service", "track"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": {
+                    "base": 1,
+                    "stops": [[9, "hsl(156, 7%, 87%)"], [11, "#e8edeb"]]
+                },
+                "line-gap-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [[6, 0], [7, 0.4], [9, 0.5], [10, 1]]
+                }
+            }
+        },
+        {
+            "id": "road-street_limited-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "none"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": {
+                    "base": 1,
+                    "stops": [[9, "hsl(156, 7%, 87%)"], [11, "#e8edeb"]]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[13, 0], [14, 2], [18, 18]]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [[6, 0], [7, 0.4], [9, 0.5], [10, 1]]
+                }
+            }
+        },
+        {
+            "id": "road-street-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                ["all", ["==", "class", "street"], ["==", "structure", "none"]]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": {
+                    "base": 1,
+                    "stops": [[9, "hsl(156, 7%, 87%)"], [11, "#e8edeb"]]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[13, 0], [14, 2], [18, 18]]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [[6, 0], [7, 0.4], [9, 0.5], [10, 1]]
+                }
+            }
+        },
+        {
+            "id": "road-main-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "class", "secondary", "tertiary"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.2, "stops": [[10, 0.75], [18, 2]]},
+                "line-color": {
+                    "base": 1,
+                    "stops": [[9, "hsl(156, 7%, 87%)"], [11, "#e8edeb"]]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[8.5, 0.5], [10, 0.75], [18, 26]]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [[6, 0], [7, 0.4], [9, 0.5], [10, 1]]
+                }
+            }
+        },
+        {
+            "id": "road-primary-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "primary"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [16, 2]]},
+                "line-color": {
+                    "base": 1,
+                    "stops": [[9, "hsl(156, 7%, 87%)"], [11, "#e8edeb"]]
+                },
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [[6, 0], [7, 0.4], [9, 0.5], [10, 1]]
+                }
+            }
+        },
+        {
+            "id": "road-motorway_link-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 10,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "motorway_link"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": {
+                    "base": 1,
+                    "stops": [[9, "hsl(156, 7%, 87%)"], [11, "#e8edeb"]]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [[6, 0], [7, 0.4], [9, 0.5], [10, 1]]
+                }
+            }
+        },
+        {
+            "id": "road-trunk_link-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "type", "trunk_link"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": {
+                    "base": 1,
+                    "stops": [[9, "hsl(156, 7%, 87%)"], [11, "#e8edeb"]]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [[6, 0], [7, 0.4], [9, 0.5], [10, 1]]
+                }
+            }
+        },
+        {
+            "id": "road-trunk-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 5,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "trunk"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[7, 0.5], [10, 1], [16, 2]]
+                },
+                "line-color": {
+                    "base": 1,
+                    "stops": [[9, "hsl(156, 7%, 87%)"], [11, "#e8edeb"]]
+                },
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[5, 0.5], [9, 1.4], [18, 32]]
+                },
+                "line-opacity": {"base": 1, "stops": [[6, 0], [6.1, 1]]}
+            }
+        },
+        {
+            "id": "road-motorway-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "motorway"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[7, 0.5], [10, 1], [16, 2]]
+                },
+                "line-color": {
+                    "base": 1,
+                    "stops": [[9, "hsl(156, 7%, 87%)"], [11, "#e8edeb"]]
+                },
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "road-construction",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "construction"],
+                    ["==", "structure", "none"]
+                ]
+            ],
+            "layout": {"line-join": "miter"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff",
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]},
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [14, [0.4, 0.8]],
+                        [15, [0.3, 0.6]],
+                        [16, [0.2, 0.3]],
+                        [17, [0.2, 0.25]],
+                        [18, [0.15, 0.15]]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "road-sidewalks",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 16,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "type", "crossing", "sidewalk"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[15, 1], [18, 4]]},
+                "line-color": "#fff",
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [1, 0.5]]
+                    ]
+                },
+                "line-opacity": {"base": 1, "stops": [[16, 0], [16.25, 1]]}
+            }
+        },
+        {
+            "id": "road-path",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["!in", "type", "crossing", "sidewalk", "steps"],
+                    ["==", "class", "path"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[15, 1], [18, 4]]},
+                "line-color": "#fff",
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [1, 0.5]]
+                    ]
+                },
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 1]]}
+            }
+        },
+        {
+            "id": "road-steps",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "type", "steps"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[15, 1], [18, 4]]},
+                "line-color": "#fff",
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [0.3, 0.3]]
+                    ]
+                },
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 1]]}
+            }
+        },
+        {
+            "id": "road-trunk_link",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "type", "trunk_link"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff",
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "road-motorway_link",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 10,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "motorway_link"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff",
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "road-pedestrian",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 12,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "pedestrian"],
+                    ["==", "structure", "none"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
+                "line-color": "#fff",
+                "line-opacity": 1,
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [[14, [1, 0]], [15, [1.5, 0.4]], [16, [1, 0.2]]]
+                }
+            }
+        },
+        {
+            "id": "road-service-link-track",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!=", "type", "trunk_link"],
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "class", "link", "service", "track"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "road-street_limited",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "none"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff",
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
+        },
+        {
+            "id": "road-street",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                ["all", ["==", "class", "street"], ["==", "structure", "none"]]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff",
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
+        },
+        {
+            "id": "road-secondary-tertiary",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "class", "secondary", "tertiary"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[8.5, 0.5], [10, 0.75], [18, 26]]
+                },
+                "line-color": "#fff",
+                "line-opacity": {"base": 1.2, "stops": [[5, 0], [5.5, 1]]}
+            }
+        },
+        {
+            "id": "road-primary",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "primary"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-color": "#fff",
+                "line-opacity": {"base": 1.2, "stops": [[5, 0], [5.5, 1]]}
+            }
+        },
+        {
+            "id": "road-trunk",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 5,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "trunk"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[5, 0.5], [9, 1.4], [18, 32]]
+                },
+                "line-color": "#fff",
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "road-motorway",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["==", "class", "motorway"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-color": "#fff",
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "road-rail",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855786460.0557"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "structure", "bridge", "tunnel"],
+                    ["in", "class", "major_rail", "minor_rail"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-color": "#e8edeb",
+                "line-width": {"base": 1, "stops": [[14, 0.75], [20, 1]]}
+            }
+        },
+        {
+            "id": "bridge-pedestrian-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "pedestrian"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[14, 2], [18, 14.5]]},
+                "line-color": "#e8edeb",
+                "line-gap-width": 0,
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
+        },
+        {
+            "id": "bridge-street-low",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "stops": [[11.5, 0], [12, 1], [14, 1], [14.01, 0]]
+                }
+            }
+        },
+        {
+            "id": "bridge-street_limited-low",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff",
+                "line-opacity": {
+                    "stops": [[11.5, 0], [12, 1], [14, 1], [14.01, 0]]
+                }
+            }
+        },
+        {
+            "id": "bridge-service-link-track-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!=", "type", "trunk_link"],
+                    ["==", "structure", "bridge"],
+                    ["in", "class", "link", "service", "track"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": "#e8edeb",
+                "line-gap-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]}
+            }
+        },
+        {
+            "id": "bridge-street_limited-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[13, 0], [14, 2], [18, 18]]
+                }
+            }
+        },
+        {
+            "id": "bridge-street-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": "#e8edeb",
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]},
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[13, 0], [14, 2], [18, 18]]
+                }
+            }
+        },
+        {
+            "id": "bridge-secondary-tertiary-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "structure", "bridge"],
+                    ["in", "class", "secondary", "tertiary"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.2, "stops": [[10, 0.75], [18, 2]]},
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[8.5, 0.5], [10, 0.75], [18, 26]]
+                },
+                "line-translate": [0, 0]
+            }
+        },
+        {
+            "id": "bridge-primary-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "primary"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [16, 2]]},
+                "line-color": "#e8edeb",
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-translate": [0, 0]
+            }
+        },
+        {
+            "id": "bridge-trunk_link-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "structure", "bridge"],
+                    ["==", "type", "trunk_link"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-opacity": {"base": 1, "stops": [[10.99, 0], [11, 1]]}
+            }
+        },
+        {
+            "id": "bridge-motorway_link-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["<=", "layer", 1],
+                    ["==", "class", "motorway_link"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "bridge-trunk-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                ["all", ["==", "class", "trunk"], ["==", "structure", "bridge"]]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[10, 1], [16, 2]]},
+                "line-color": "#e8edeb",
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]}
+            }
+        },
+        {
+            "id": "bridge-motorway-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "motorway"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[7, 0.5], [10, 1], [16, 2]]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]}
+            }
+        },
+        {
+            "id": "bridge-construction",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "construction"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-join": "miter"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff",
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]},
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [14, [0.4, 0.8]],
+                        [15, [0.3, 0.6]],
+                        [16, [0.2, 0.3]],
+                        [17, [0.2, 0.25]],
+                        [18, [0.15, 0.15]]
+                    ]
+                }
+            }
+        },
+        {
+            "id": "bridge-path",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!=", "type", "steps"],
+                    ["==", "class", "path"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[15, 1], [18, 4]]},
+                "line-color": "#fff",
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [1, 0.5]]
+                    ]
+                },
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 1]]}
+            }
+        },
+        {
+            "id": "bridge-steps",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                ["all", ["==", "structure", "bridge"], ["==", "type", "steps"]]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[15, 1], [18, 4]]},
+                "line-color": "#fff",
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [
+                        [14, [1, 0]],
+                        [15, [1.75, 1]],
+                        [16, [1, 0.75]],
+                        [17, [0.3, 0.3]]
+                    ]
+                },
+                "line-opacity": {"base": 1, "stops": [[14, 0], [14.25, 1]]}
+            }
+        },
+        {
+            "id": "bridge-trunk_link",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "layer", 2, 3, 4, 5],
+                    ["==", "structure", "bridge"],
+                    ["==", "type", "trunk_link"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-motorway_link",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "layer", 2, 3, 4, 5],
+                    ["==", "class", "motorway_link"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-pedestrian",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "pedestrian"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
+                "line-color": "#fff",
+                "line-opacity": 1,
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [[14, [1, 0]], [15, [1.5, 0.4]], [16, [1, 0.2]]]
+                }
+            }
+        },
+        {
+            "id": "bridge-service-link-track",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 14,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!=", "type", "trunk_link"],
+                    ["==", "structure", "bridge"],
+                    ["in", "class", "link", "service", "track"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[14, 0.5], [18, 12]]},
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-street_limited",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street_limited"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff",
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
+        },
+        {
+            "id": "bridge-street",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 11,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "street"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12.5, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff",
+                "line-opacity": {"base": 1, "stops": [[13.99, 0], [14, 1]]}
+            }
+        },
+        {
+            "id": "bridge-secondary-tertiary",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "structure", "bridge"],
+                    ["in", "type", "secondary", "tertiary"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[8.5, 0.5], [10, 0.75], [18, 26]]
+                },
+                "line-color": "#fff",
+                "line-opacity": {"base": 1.2, "stops": [[5, 0], [5.5, 1]]}
+            }
+        },
+        {
+            "id": "bridge-primary",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "structure", "bridge"],
+                    ["==", "type", "primary"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-color": "#fff",
+                "line-opacity": {"base": 1.2, "stops": [[5, 0], [5.5, 1]]}
+            }
+        },
+        {
+            "id": "bridge-trunk",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "layer", 2, 3, 4, 5],
+                    ["==", "class", "trunk"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-motorway",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["!in", "layer", 2, 3, 4, 5],
+                    ["==", "class", "motorway"],
+                    ["==", "structure", "bridge"]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-rail",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "structure", "bridge"],
+                    ["in", "class", "major_rail", "minor_rail"]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-color": "#e8edeb",
+                "line-width": {"base": 1, "stops": [[14, 0.75], [20, 1]]}
+            }
+        },
+        {
+            "id": "bridge-trunk_link-2-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "structure", "bridge"],
+                    ["==", "type", "trunk_link"],
+                    [">=", "layer", 2]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-opacity": {"base": 1, "stops": [[10.99, 0], [11, 1]]}
+            }
+        },
+        {
+            "id": "bridge-motorway_link-2-case copy",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "motorway_link"],
+                    ["==", "structure", "bridge"],
+                    [">=", "layer", 2]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[12, 0.75], [20, 2]]},
+                "line-color": "#e8edeb",
+                "line-gap-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-opacity": 1
+            }
+        },
+        {
+            "id": "bridge-trunk-2-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "trunk"],
+                    ["==", "structure", "bridge"],
+                    [">=", "layer", 2]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[10, 1], [16, 2]]},
+                "line-color": "#e8edeb",
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]}
+            }
+        },
+        {
+            "id": "bridge-motorway-2-case",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "motorway"],
+                    ["==", "structure", "bridge"],
+                    [">=", "layer", 2]
+                ]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[7, 0.5], [10, 1], [16, 2]]
+                },
+                "line-color": "#e8edeb",
+                "line-gap-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]}
+            }
+        },
+        {
+            "id": "bridge-trunk_link-2",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "structure", "bridge"],
+                    ["==", "type", "trunk_link"],
+                    [">=", "layer", 2]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-motorway_link-2",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "motorway_link"],
+                    ["==", "structure", "bridge"],
+                    [">=", "layer", 2]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {
+                    "base": 1.5,
+                    "stops": [[12, 0.5], [14, 2], [18, 18]]
+                },
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-trunk-2",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "trunk"],
+                    ["==", "structure", "bridge"],
+                    [">=", "layer", 2]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "bridge-motorway-2",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444855799204.86"},
+            "source": "composite",
+            "source-layer": "road",
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "class", "motorway"],
+                    ["==", "structure", "bridge"],
+                    [">=", "layer", 2]
+                ]
+            ],
+            "layout": {"line-cap": "round", "line-join": "round"},
+            "paint": {
+                "line-width": {"base": 1.5, "stops": [[5, 0.75], [18, 32]]},
+                "line-color": "#fff"
+            }
+        },
+        {
+            "id": "admin-3-4-boundaries-bg",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444934295202.7542"},
+            "source": "composite",
+            "source-layer": "admin",
+            "filter": ["all", ["==", "maritime", 0], [">=", "admin_level", 3]],
+            "layout": {"line-join": "bevel"},
+            "paint": {
+                "line-color": "hsl(0, 0%, 84%)",
+                "line-width": {"base": 1, "stops": [[3, 3.5], [10, 8]]},
+                "line-opacity": {
+                    "base": 1,
+                    "stops": [[4, 0], [7, 0.5], [8, 0.75]]
+                },
+                "line-dasharray": [1, 0],
+                "line-translate": [0, 0],
+                "line-blur": {"base": 1, "stops": [[3, 0], [8, 3]]}
+            }
+        },
+        {
+            "id": "admin-2-boundaries-bg",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444934295202.7542"},
+            "source": "composite",
+            "source-layer": "admin",
+            "minzoom": 1,
+            "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
+            "layout": {"line-join": "miter"},
+            "paint": {
+                "line-width": {"base": 1, "stops": [[3, 3.5], [10, 10]]},
+                "line-color": "hsl(0, 0%, 84%)",
+                "line-opacity": {"base": 1, "stops": [[3, 0], [4, 0.5]]},
+                "line-translate": [0, 0],
+                "line-blur": {"base": 1, "stops": [[3, 0], [10, 2]]}
+            }
+        },
+        {
+            "id": "admin-3-4-boundaries",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444934295202.7542"},
+            "source": "composite",
+            "source-layer": "admin",
+            "filter": ["all", ["==", "maritime", 0], [">=", "admin_level", 3]],
+            "layout": {"line-join": "round", "line-cap": "round"},
+            "paint": {
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [[6, [2, 0]], [7, [2, 2, 6, 2]]]
+                },
+                "line-width": {"base": 1, "stops": [[7, 0.75], [12, 1.5]]},
+                "line-opacity": {"base": 1, "stops": [[2, 0], [3, 1]]},
+                "line-color": {
+                    "base": 1,
+                    "stops": [[4, "hsl(0, 0%, 80%)"], [5, "hsl(0, 0%, 70%)"]]
+                }
+            }
+        },
+        {
+            "id": "admin-2-boundaries",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444934295202.7542"},
+            "source": "composite",
+            "source-layer": "admin",
+            "minzoom": 1,
+            "filter": [
+                "all",
+                ["==", "admin_level", 2],
+                ["==", "disputed", 0],
+                ["==", "maritime", 0]
+            ],
+            "layout": {"line-join": "round", "line-cap": "round"},
+            "paint": {
+                "line-color": {
+                    "base": 1,
+                    "stops": [[3, "hsl(0, 0%, 70%)"], [4, "hsl(0, 0%, 62%)"]]
+                },
+                "line-width": {"base": 1, "stops": [[3, 0.5], [10, 2]]}
+            }
+        },
+        {
+            "id": "admin-2-boundaries-dispute",
+            "type": "line",
+            "metadata": {"mapbox:group": "1444934295202.7542"},
+            "source": "composite",
+            "source-layer": "admin",
+            "minzoom": 1,
+            "filter": [
+                "all",
+                ["==", "admin_level", 2],
+                ["==", "disputed", 1],
+                ["==", "maritime", 0]
+            ],
+            "layout": {"line-join": "round"},
+            "paint": {
+                "line-dasharray": [1.5, 1.5],
+                "line-color": {
+                    "base": 1,
+                    "stops": [[3, "hsl(0, 0%, 70%)"], [4, "hsl(0, 0%, 62%)"]]
+                },
+                "line-width": {"base": 1, "stops": [[3, 0.5], [10, 2]]}
+            }
+        },
+        {
+            "id": "bicycle-lanes-dp63et",
+            "type": "line",
+            "source": "composite",
+            "source-layer": "Bicycle_Lanes-dp63et",
+            "layout": {"visibility": "none"},
+            "paint": {
+                "line-color": {
+                    "base": 1,
+                    "type": "categorical",
+                    "property": "FACILITY",
+                    "stops": [
+                        ["Contraflow Bike Lane", "hsl(260, 69%, 68%)"],
+                        ["Cycle Track", "hsl(0, 69%, 68%)"],
+                        ["Climbing Lane", "hsl(0, 69%, 68%)"],
+                        ["Shared Lane", "hsl(0, 40%, 83%)"],
+                        ["Bus/Bike Lane", "hsl(0, 40%, 83%)"]
+                    ],
+                    "default": "hsl(0, 69%, 68%)"
+                },
+                "line-width": {"base": 1.5, "stops": [[12, 1], [18, 4]]}
+            }
+        },
+        {
+            "id": "bicycle-lanes-dedicated",
+            "type": "line",
+            "source": "composite",
+            "source-layer": "Bicycle_Lanes-dp63et",
+            "filter": [
+                "in",
+                "FACILITY",
+                "Climbing Lane",
+                "Contraflow Bike Lane",
+                "Cycle Track",
+                "Existing Bike Lane"
+            ],
+            "layout": {"visibility": "visible"},
+            "paint": {
+                "line-color": {
+                    "base": 1,
+                    "type": "categorical",
+                    "property": "FACILITY",
+                    "stops": [["Cycle Track", "hsl(228, 83%, 76%)"]],
+                    "default": "hsl(0, 79%, 76%)"
+                },
+                "line-width": {"base": 1.5, "stops": [[12, 1], [18, 4]]}
+            }
+        },
+        {
+            "id": "bicycle-lanes-shared-or-bus",
+            "type": "line",
+            "source": "composite",
+            "source-layer": "Bicycle_Lanes-dp63et",
+            "filter": ["in", "FACILITY", "Bus/Bike Lane", "Shared Lane"],
+            "layout": {"visibility": "visible"},
+            "paint": {
+                "line-color": "hsl(0, 79%, 76%)",
+                "line-width": {"base": 1.5, "stops": [[12, 1], [18, 4]]},
+                "line-dasharray": {
+                    "base": 1,
+                    "stops": [[0, [1, 1]], [15, [2, 1]]]
+                }
+            }
+        },
+        {
+            "id": "bicycle-lanes-contraflow-arrow",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "Bicycle_Lanes-dp63et",
+            "minzoom": 15,
+            "filter": ["==", "FACILITY", "Contraflow Bike Lane"],
+            "layout": {
+                "icon-image": "oneway-bike",
+                "symbol-placement": "line",
+                "symbol-spacing": 100
+            },
+            "paint": {}
+        },
+        {
+            "id": "oneway-large",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 15,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "oneway", "true"],
+                    [
+                        "in",
+                        "class",
+                        "path",
+                        "primary",
+                        "secondary",
+                        "street",
+                        "street_limited",
+                        "tertiary"
+                    ]
+                ]
+            ],
+            "layout": {"icon-image": "oneway", "symbol-placement": "line"},
+            "paint": {}
+        },
+        {
+            "id": "oneway-small",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "road",
+            "minzoom": 16,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "all",
+                    ["==", "oneway", "true"],
+                    ["in", "class", "link", "service", "track"]
+                ]
+            ],
+            "layout": {"icon-image": "oneway", "symbol-placement": "line"},
+            "paint": {}
+        },
+        {
+            "id": "waterway-label",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "waterway_label",
+            "minzoom": 12,
+            "filter": ["in", "class", "canal", "river"],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-font": [
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
+                ],
+                "symbol-placement": "line",
+                "text-pitch-alignment": "viewport",
+                "text-max-angle": 30,
+                "text-size": {"base": 1, "stops": [[13, 12], [18, 16]]}
+            },
+            "paint": {
+                "text-halo-width": 0,
+                "text-halo-blur": 0,
+                "text-color": "#78888a"
+            }
+        },
+        {
+            "id": "poi-scalerank3",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444933372896.5967"},
+            "source": "composite",
+            "source-layer": "poi_label",
+            "filter": [
+                "all",
+                [
+                    "!in",
+                    "maki",
+                    "campsite",
+                    "cemetery",
+                    "dog-park",
+                    "garden",
+                    "golf",
+                    "park",
+                    "picnic-site",
+                    "playground",
+                    "zoo"
+                ],
+                ["==", "scalerank", 3]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {"base": 1, "stops": [[16, 11], [20, 13]]},
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 1,
+                "visibility": "none",
+                "text-offset": [0, 0],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
+            },
+            "paint": {
+                "text-color": "#949494",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "poi-parks-scalerank3",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444933372896.5967"},
+            "source": "composite",
+            "source-layer": "poi_label",
+            "filter": [
+                "all",
+                ["==", "scalerank", 3],
+                [
+                    "in",
+                    "maki",
+                    "campsite",
+                    "cemetery",
+                    "dog-park",
+                    "garden",
+                    "golf",
+                    "park",
+                    "picnic-site",
+                    "playground",
+                    "zoo"
+                ]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {"base": 1, "stops": [[16, 11], [20, 12]]},
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "visibility": "none",
+                "text-offset": [0, 0],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
+            },
+            "paint": {
+                "text-halo-blur": 0,
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-color": "#949494"
+            }
+        },
+        {
+            "id": "road-label-small",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444933721429.3076"},
+            "source": "composite",
+            "source-layer": "road_label",
+            "minzoom": 15,
+            "filter": [
+                "all",
+                [
+                    "!in",
+                    "class",
+                    "ferry",
+                    "golf",
+                    "link",
+                    "motorway",
+                    "pedestrian",
+                    "primary",
+                    "secondary",
+                    "street",
+                    "street_limited",
+                    "tertiary",
+                    "trunk"
+                ],
+                ["==", "$type", "LineString"]
+            ],
+            "layout": {
+                "text-size": {"base": 1, "stops": [[15, 10], [20, 13]]},
+                "text-max-angle": 30,
+                "symbol-spacing": 500,
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "symbol-placement": "line",
+                "text-padding": 1,
+                "text-offset": {
+                    "base": 1,
+                    "stops": [[15, [0, 0.5]], [20, [0, 1.2]]]
+                },
+                "text-rotation-alignment": "map",
+                "text-pitch-alignment": "viewport",
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 30%)",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1.25,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "road-label-medium",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444933721429.3076"},
+            "source": "composite",
+            "source-layer": "road_label",
+            "minzoom": 13,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [
+                    "in",
+                    "class",
+                    "link",
+                    "pedestrian",
+                    "street",
+                    "street_limited"
+                ]
+            ],
+            "layout": {
+                "text-size": {"base": 1, "stops": [[11, 10], [20, 14]]},
+                "text-max-angle": 30,
+                "symbol-spacing": 500,
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "symbol-placement": "line",
+                "text-padding": 1,
+                "text-offset": {
+                    "base": 1,
+                    "stops": [[11, [0, 0]], [20, [0, 1.3]]]
+                },
+                "text-rotation-alignment": "map",
+                "text-pitch-alignment": "viewport",
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 30%)",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "road-label-large",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444933721429.3076"},
+            "source": "composite",
+            "source-layer": "road_label",
+            "minzoom": 12,
+            "filter": [
+                "in",
+                "class",
+                "motorway",
+                "primary",
+                "secondary",
+                "tertiary",
+                "trunk"
+            ],
+            "layout": {
+                "text-size": {"base": 1, "stops": [[9, 10], [20, 16]]},
+                "text-max-angle": 30,
+                "symbol-spacing": 400,
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "symbol-placement": "line",
+                "text-padding": 1,
+                "text-offset": {
+                    "base": 1,
+                    "stops": [[9, [0, 0]], [20, [0, 1.4]]]
+                },
+                "text-rotation-alignment": "map",
+                "text-pitch-alignment": "viewport",
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 30%)",
+                "text-halo-color": "rgba(255,255,255, 0.75)",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "poi-scalerank2",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444933358918.2366"},
+            "source": "composite",
+            "source-layer": "poi_label",
+            "filter": [
+                "all",
+                [
+                    "!in",
+                    "maki",
+                    "campsite",
+                    "cemetery",
+                    "dog-park",
+                    "garden",
+                    "golf",
+                    "park",
+                    "picnic-site",
+                    "playground",
+                    "zoo"
+                ],
+                ["==", "scalerank", 2]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {"base": 1, "stops": [[14, 11], [20, 12]]},
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "text-offset": [0, 0],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
+            },
+            "paint": {
+                "text-color": "#949494",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "poi-parks-scalerank2",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444933358918.2366"},
+            "source": "composite",
+            "source-layer": "poi_label",
+            "filter": [
+                "all",
+                ["==", "scalerank", 2],
+                [
+                    "in",
+                    "maki",
+                    "campsite",
+                    "cemetery",
+                    "dog-park",
+                    "garden",
+                    "golf",
+                    "park",
+                    "picnic-site",
+                    "playground",
+                    "zoo"
+                ]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {"base": 1, "stops": [[14, 11], [20, 12]]},
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "text-offset": [0, 0],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
+            },
+            "paint": {
+                "text-color": "#949494",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "water-label",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444933808272.805"},
+            "source": "composite",
+            "source-layer": "water_label",
+            "minzoom": 5,
+            "filter": [">", "area", 10000],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-font": [
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-max-width": 7,
+                "text-size": {"base": 1, "stops": [[13, 13], [18, 18]]}
+            },
+            "paint": {"text-color": "#78888a", "text-halo-blur": 0}
+        },
+        {
+            "id": "poi-parks-scalerank1",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444933322393.2852"},
+            "source": "composite",
+            "source-layer": "poi_label",
+            "filter": [
+                "all",
+                ["<=", "scalerank", 1],
+                [
+                    "in",
+                    "maki",
+                    "campsite",
+                    "cemetery",
+                    "dog-park",
+                    "garden",
+                    "golf",
+                    "park",
+                    "picnic-site",
+                    "playground",
+                    "zoo"
+                ]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {"base": 1, "stops": [[10, 11], [18, 12]]},
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "text-offset": [0, 0],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 58%)",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "poi-scalerank1",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444933322393.2852"},
+            "source": "composite",
+            "source-layer": "poi_label",
+            "filter": [
+                "all",
+                [
+                    "!in",
+                    "maki",
+                    "campsite",
+                    "cemetery",
+                    "dog-park",
+                    "garden",
+                    "golf",
+                    "park",
+                    "picnic-site",
+                    "playground",
+                    "zoo"
+                ],
+                ["<=", "scalerank", 1]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {"base": 1, "stops": [[10, 11], [18, 12]]},
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "text-offset": [0, 0],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 58%)",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "airport-label",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "airport_label",
+            "minzoom": 10,
+            "filter": ["<=", "scalerank", 2],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {"base": 1, "stops": [[10, 12], [18, 18]]},
+                "icon-image": {"stops": [[12, "{maki}-11"], [13, "{maki}-15"]]},
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "text-offset": [0, 0.75],
+                "text-anchor": "top",
+                "text-field": {"stops": [[11, "{ref}"], [14, "{name_en}"]]},
+                "text-letter-spacing": 0.01,
+                "text-max-width": 9
+            },
+            "paint": {
+                "text-color": "#6B6B6B",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 0.5,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-islets-archipelago-aboriginal",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "maxzoom": 16,
+            "filter": [
+                "in",
+                "type",
+                "aboriginal_lands",
+                "archipelago",
+                "islet"
+            ],
+            "layout": {
+                "text-line-height": 1.2,
+                "text-size": {"base": 1, "stops": [[10, 11], [18, 16]]},
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "text-offset": [0, 0],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 8
+            },
+            "paint": {
+                "text-color": "#6B6B6B",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-neighbourhood",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 12,
+            "maxzoom": 16,
+            "filter": ["==", "type", "neighbourhood"],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-transform": "uppercase",
+                "text-letter-spacing": 0.1,
+                "text-max-width": 7,
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 3,
+                "text-size": {"base": 1, "stops": [[12, 11], [16, 16]]}
+            },
+            "paint": {
+                "text-halo-color": "hsl(0, 0%, 100%)",
+                "text-halo-width": 1.5,
+                "text-color": "hsl(0, 0%, 62%)",
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-suburb",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 11,
+            "maxzoom": 16,
+            "filter": ["==", "type", "suburb"],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-transform": "uppercase",
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-letter-spacing": 0.15,
+                "text-max-width": 7,
+                "text-padding": 3,
+                "text-size": {"base": 1, "stops": [[11, 11], [15, 18]]}
+            },
+            "paint": {
+                "text-halo-color": "hsl(0, 0%, 100%)",
+                "text-halo-width": 1.5,
+                "text-color": "hsl(0, 0%, 62%)",
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-hamlet",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 10,
+            "maxzoom": 16,
+            "filter": ["==", "type", "hamlet"],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-size": {"base": 1, "stops": [[12, 11.5], [15, 16]]}
+            },
+            "paint": {
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1.25,
+                "text-color": "hsl(0, 0%, 62%)",
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-village",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 11,
+            "maxzoom": 15,
+            "filter": ["==", "type", "village"],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-max-width": 7,
+                "text-size": {"base": 1, "stops": [[10, 11.5], [16, 18]]},
+                "text-offset": [0, 0]
+            },
+            "paint": {
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1.25,
+                "text-color": {
+                    "base": 1,
+                    "stops": [[10, "hsl(0, 0%, 62%)"], [11, "hsl(0, 0%, 55%)"]]
+                },
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-town",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 7,
+            "maxzoom": 15,
+            "filter": ["==", "type", "town"],
+            "layout": {
+                "text-size": {"base": 1, "stops": [[7, 11.5], [15, 20]]},
+                "text-font": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            11,
+                            ["DIN Offc Pro Regular", "Arial Unicode MS Regular"]
+                        ],
+                        [
+                            12,
+                            ["DIN Offc Pro Medium", "Arial Unicode MS Regular"]
+                        ]
+                    ]
+                },
+                "text-padding": 2,
+                "text-offset": [0, 0],
+                "text-field": "{name_en}",
+                "text-max-width": 7
+            },
+            "paint": {
+                "text-color": {
+                    "base": 1,
+                    "stops": [[10, "hsl(0, 0%, 62%)"], [11, "hsl(0, 0%, 55%)"]]
+                },
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1.25,
+                "icon-opacity": {"base": 1, "stops": [[7.99, 1], [8, 0]]},
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-islands",
+            "type": "symbol",
+            "source": "composite",
+            "source-layer": "place_label",
+            "maxzoom": 16,
+            "filter": ["==", "type", "island"],
+            "layout": {
+                "text-line-height": 1.2,
+                "text-size": {"base": 1, "stops": [[10, 11], [18, 16]]},
+                "text-max-angle": 38,
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Regular",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-padding": 2,
+                "text-offset": [0, 0],
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.01,
+                "text-max-width": 7
+            },
+            "paint": {
+                "text-color": "#6B6B6B",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-city-sm",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444862510685.128"},
+            "source": "composite",
+            "source-layer": "place_label",
+            "maxzoom": 12,
+            "filter": [
+                "all",
+                ["!in", "scalerank", 0, 1, 2, 3, 4, 5],
+                ["==", "type", "city"]
+            ],
+            "layout": {
+                "text-size": {"base": 1, "stops": [[6, 12], [14, 22]]},
+                "text-font": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7,
+                            ["DIN Offc Pro Regular", "Arial Unicode MS Regular"]
+                        ],
+                        [8, ["DIN Offc Pro Medium", "Arial Unicode MS Regular"]]
+                    ]
+                },
+                "text-offset": [0, 0],
+                "text-field": "{name_en}",
+                "text-max-width": 7
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 42%)",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1.25,
+                "icon-opacity": {"base": 1, "stops": [[7.99, 1], [8, 0]]},
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-city-md-s",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444862510685.128"},
+            "source": "composite",
+            "source-layer": "place_label",
+            "maxzoom": 12,
+            "filter": [
+                "all",
+                ["==", "type", "city"],
+                ["in", "ldir", "E", "S", "SE", "SW"],
+                ["in", "scalerank", 3, 4, 5]
+            ],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-size": {"base": 0.9, "stops": [[5, 12], [12, 22]]},
+                "text-anchor": "top",
+                "text-offset": {
+                    "base": 1,
+                    "stops": [[7.99, [0, 0.1]], [8, [0, 0]]]
+                },
+                "text-font": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7,
+                            ["DIN Offc Pro Regular", "Arial Unicode MS Regular"]
+                        ],
+                        [8, ["DIN Offc Pro Medium", "Arial Unicode MS Regular"]]
+                    ]
+                },
+                "icon-image": "dot-10"
+            },
+            "paint": {
+                "text-halo-width": 1,
+                "text-halo-color": "#ffffff",
+                "text-color": "hsl(0, 0%, 42%)",
+                "text-halo-blur": 0,
+                "icon-opacity": {"base": 1, "stops": [[7.99, 1], [8, 0]]}
+            }
+        },
+        {
+            "id": "place-city-md-n",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444862510685.128"},
+            "source": "composite",
+            "source-layer": "place_label",
+            "maxzoom": 12,
+            "filter": [
+                "all",
+                ["==", "type", "city"],
+                ["in", "ldir", "N", "NE", "NW", "W"],
+                ["in", "scalerank", 3, 4, 5]
+            ],
+            "layout": {
+                "text-size": {"base": 0.9, "stops": [[5, 12], [12, 22]]},
+                "text-font": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7,
+                            ["DIN Offc Pro Regular", "Arial Unicode MS Regular"]
+                        ],
+                        [8, ["DIN Offc Pro Medium", "Arial Unicode MS Regular"]]
+                    ]
+                },
+                "text-offset": {
+                    "base": 1,
+                    "stops": [[7.99, [0, -0.25]], [8, [0, 0]]]
+                },
+                "text-anchor": "bottom",
+                "text-field": "{name_en}",
+                "text-max-width": 7,
+                "icon-image": "dot-10"
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 42%)",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "icon-opacity": {"base": 1, "stops": [[7.99, 1], [8, 0]]},
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-city-lg-s",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444862510685.128"},
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 1,
+            "maxzoom": 12,
+            "filter": [
+                "all",
+                ["<=", "scalerank", 2],
+                ["==", "type", "city"],
+                ["in", "ldir", "E", "S", "SE", "SW"]
+            ],
+            "layout": {
+                "text-size": {"base": 0.9, "stops": [[4, 12], [10, 22]]},
+                "icon-image": "dot-11",
+                "text-font": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7,
+                            ["DIN Offc Pro Regular", "Arial Unicode MS Regular"]
+                        ],
+                        [8, ["DIN Offc Pro Medium", "Arial Unicode MS Regular"]]
+                    ]
+                },
+                "text-offset": {
+                    "base": 1,
+                    "stops": [[7.99, [0, 0.15]], [8, [0, 0]]]
+                },
+                "icon-size": 1,
+                "text-anchor": {
+                    "base": 1,
+                    "stops": [[7, "top"], [8, "center"]]
+                },
+                "text-field": "{name_en}",
+                "text-max-width": 7
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 42%)",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "icon-opacity": {"base": 1, "stops": [[7.99, 1], [8, 0]]},
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "place-city-lg-n",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444862510685.128"},
+            "source": "composite",
+            "source-layer": "place_label",
+            "minzoom": 1,
+            "maxzoom": 12,
+            "filter": [
+                "all",
+                ["<=", "scalerank", 2],
+                ["==", "type", "city"],
+                ["in", "ldir", "N", "NE", "NW", "W"]
+            ],
+            "layout": {
+                "text-size": {"base": 0.9, "stops": [[4, 12], [10, 22]]},
+                "icon-image": "dot-11",
+                "text-font": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            7,
+                            ["DIN Offc Pro Regular", "Arial Unicode MS Regular"]
+                        ],
+                        [8, ["DIN Offc Pro Medium", "Arial Unicode MS Regular"]]
+                    ]
+                },
+                "text-offset": {
+                    "base": 1,
+                    "stops": [[7.99, [0, -0.25]], [8, [0, 0]]]
+                },
+                "icon-size": 1,
+                "text-anchor": {
+                    "base": 1,
+                    "stops": [[7, "bottom"], [8, "center"]]
+                },
+                "text-field": "{name_en}",
+                "text-max-width": 7
+            },
+            "paint": {
+                "text-color": "hsl(0, 0%, 42%)",
+                "text-opacity": 1,
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "icon-opacity": {"base": 1, "stops": [[7.99, 1], [8, 0]]},
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "marine-label-sm-ln",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444856087950.3635"},
+            "source": "composite",
+            "source-layer": "marine_label",
+            "minzoom": 3,
+            "maxzoom": 10,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                [">=", "labelrank", 4]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {"base": 1, "stops": [[3, 12], [6, 16]]},
+                "symbol-spacing": {"base": 1, "stops": [[4, 100], [6, 400]]},
+                "text-font": [
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
+                ],
+                "symbol-placement": "line",
+                "text-pitch-alignment": "viewport",
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.1,
+                "text-max-width": 5
+            },
+            "paint": {"text-color": "#78888a", "text-halo-blur": 0}
+        },
+        {
+            "id": "marine-label-sm-pt",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444856087950.3635"},
+            "source": "composite",
+            "source-layer": "marine_label",
+            "minzoom": 3,
+            "maxzoom": 10,
+            "filter": ["all", ["==", "$type", "Point"], [">=", "labelrank", 4]],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-max-width": 5,
+                "text-letter-spacing": 0.1,
+                "text-line-height": 1.5,
+                "text-font": [
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-size": {"base": 1, "stops": [[3, 12], [6, 16]]}
+            },
+            "paint": {"text-color": "#78888a", "text-halo-blur": 0}
+        },
+        {
+            "id": "marine-label-md-ln",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444856087950.3635"},
+            "source": "composite",
+            "source-layer": "marine_label",
+            "minzoom": 2,
+            "maxzoom": 8,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                ["in", "labelrank", 2, 3]
+            ],
+            "layout": {
+                "text-line-height": 1.1,
+                "text-size": {"base": 1.1, "stops": [[2, 12], [5, 20]]},
+                "symbol-spacing": 250,
+                "text-font": [
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
+                ],
+                "symbol-placement": "line",
+                "text-pitch-alignment": "viewport",
+                "text-field": "{name_en}",
+                "text-letter-spacing": 0.15,
+                "text-max-width": 5
+            },
+            "paint": {"text-color": "#78888a", "text-halo-blur": 0}
+        },
+        {
+            "id": "marine-label-md-pt",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444856087950.3635"},
+            "source": "composite",
+            "source-layer": "marine_label",
+            "minzoom": 2,
+            "maxzoom": 8,
+            "filter": [
+                "all",
+                ["==", "$type", "Point"],
+                ["in", "labelrank", 2, 3]
+            ],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-max-width": 5,
+                "text-letter-spacing": 0.15,
+                "text-line-height": 1.5,
+                "text-font": [
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-size": {"base": 1.1, "stops": [[2, 14], [5, 20]]}
+            },
+            "paint": {"text-color": "#78888a", "text-halo-blur": 0}
+        },
+        {
+            "id": "marine-label-lg-ln",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444856087950.3635"},
+            "source": "composite",
+            "source-layer": "marine_label",
+            "minzoom": 1,
+            "maxzoom": 4,
+            "filter": [
+                "all",
+                ["==", "$type", "LineString"],
+                ["==", "labelrank", 1]
+            ],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-max-width": 4,
+                "text-letter-spacing": 0.25,
+                "text-line-height": 1.1,
+                "symbol-placement": "line",
+                "text-pitch-alignment": "viewport",
+                "text-font": [
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-size": {"base": 1, "stops": [[1, 14], [4, 30]]}
+            },
+            "paint": {"text-color": "#78888a", "text-halo-blur": 0}
+        },
+        {
+            "id": "marine-label-lg-pt",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444856087950.3635"},
+            "source": "composite",
+            "source-layer": "marine_label",
+            "minzoom": 1,
+            "maxzoom": 4,
+            "filter": ["all", ["==", "$type", "Point"], ["==", "labelrank", 1]],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-max-width": 4,
+                "text-letter-spacing": 0.25,
+                "text-line-height": 1.5,
+                "text-font": [
+                    "DIN Offc Pro Italic",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-size": {"base": 1, "stops": [[1, 14], [4, 30]]}
+            },
+            "paint": {"text-color": "#78888a", "text-halo-blur": 0}
+        },
+        {
+            "id": "state-label-sm",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444856151690.9143"},
+            "source": "composite",
+            "source-layer": "state_label",
+            "minzoom": 3,
+            "maxzoom": 9,
+            "filter": ["<", "area", 20000],
+            "layout": {
+                "text-size": {"base": 1, "stops": [[6, 10], [9, 14]]},
+                "text-transform": "uppercase",
+                "text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"],
+                "text-field": {
+                    "base": 1,
+                    "stops": [[0, "{abbr}"], [6, "{name_en}"]]
+                },
+                "text-letter-spacing": 0.15,
+                "text-max-width": 5
+            },
+            "paint": {
+                "text-opacity": 1,
+                "text-color": "#a8a8a8",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "state-label-md",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444856151690.9143"},
+            "source": "composite",
+            "source-layer": "state_label",
+            "minzoom": 3,
+            "maxzoom": 8,
+            "filter": ["all", ["<", "area", 80000], [">=", "area", 20000]],
+            "layout": {
+                "text-size": {"base": 1, "stops": [[5, 10], [8, 16]]},
+                "text-transform": "uppercase",
+                "text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"],
+                "text-field": {
+                    "base": 1,
+                    "stops": [[0, "{abbr}"], [5, "{name_en}"]]
+                },
+                "text-letter-spacing": 0.15,
+                "text-max-width": 6
+            },
+            "paint": {
+                "text-opacity": 1,
+                "text-color": "#a8a8a8",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "state-label-lg",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444856151690.9143"},
+            "source": "composite",
+            "source-layer": "state_label",
+            "minzoom": 3,
+            "maxzoom": 7,
+            "filter": [">=", "area", 80000],
+            "layout": {
+                "text-size": {"base": 1, "stops": [[4, 10], [7, 18]]},
+                "text-transform": "uppercase",
+                "text-font": ["DIN Offc Pro Bold", "Arial Unicode MS Bold"],
+                "text-padding": 1,
+                "text-field": {
+                    "base": 1,
+                    "stops": [[0, "{abbr}"], [4, "{name_en}"]]
+                },
+                "text-letter-spacing": 0.15,
+                "text-max-width": 6
+            },
+            "paint": {
+                "text-opacity": 1,
+                "text-color": "#a8a8a8",
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 1,
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "country-label-sm",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444856144497.7825"},
+            "source": "composite",
+            "source-layer": "country_label",
+            "minzoom": 1,
+            "maxzoom": 10,
+            "filter": [">=", "scalerank", 5],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-max-width": 6,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-size": {"base": 0.9, "stops": [[5, 14], [9, 22]]}
+            },
+            "paint": {
+                "text-halo-width": 1.25,
+                "text-halo-color": {
+                    "base": 1,
+                    "stops": [[2, "rgba(255,255,255,0.75)"], [3, "#fff"]]
+                },
+                "text-color": "#6b6b6b",
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "country-label-md",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444856144497.7825"},
+            "source": "composite",
+            "source-layer": "country_label",
+            "minzoom": 1,
+            "maxzoom": 8,
+            "filter": ["in", "scalerank", 3, 4],
+            "layout": {
+                "text-field": {
+                    "base": 1,
+                    "stops": [[0, "{code}"], [2, "{name_en}"]]
+                },
+                "text-max-width": 6,
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-size": {"base": 1, "stops": [[3, 10], [8, 24]]}
+            },
+            "paint": {
+                "text-halo-width": 1.25,
+                "text-halo-color": {
+                    "base": 1,
+                    "stops": [[2, "rgba(255,255,255,0.75)"], [3, "#fff"]]
+                },
+                "text-color": "#6b6b6b",
+                "text-halo-blur": 0
+            }
+        },
+        {
+            "id": "country-label-lg",
+            "type": "symbol",
+            "metadata": {"mapbox:group": "1444856144497.7825"},
+            "source": "composite",
+            "source-layer": "country_label",
+            "minzoom": 1,
+            "maxzoom": 7,
+            "filter": ["in", "scalerank", 1, 2],
+            "layout": {
+                "text-field": "{name_en}",
+                "text-max-width": {"base": 1, "stops": [[0, 5], [3, 6]]},
+                "text-font": [
+                    "DIN Offc Pro Medium",
+                    "Arial Unicode MS Regular"
+                ],
+                "text-size": {"base": 1, "stops": [[1, 10], [6, 24]]}
+            },
+            "paint": {
+                "text-halo-width": 1.25,
+                "text-halo-color": {
+                    "base": 1,
+                    "stops": [[2, "rgba(255,255,255,0.75)"], [3, "#fff"]]
+                },
+                "text-color": "#6b6b6b",
+                "text-halo-blur": 0
+            }
+        }
+    ],
+    "created": "2017-12-06T15:39:36.502Z",
+    "id": "cjav7yuqylrmk2speysk7tz9y",
+    "modified": "2017-12-19T01:14:50.142Z",
+    "owner": "nicki",
+    "visibility": "public",
+    "draft": false
+}

--- a/add-bike-lane-style.json
+++ b/add-bike-lane-style.json
@@ -42,7 +42,7 @@
     "pitch": 0,
     "sources": {
         "composite": {
-            "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,nicki.daq6vzck,nicki.382btzl6,k-mahoney.9p18idhz",
+            "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,nicki.daq6vzck,nicki.382btzl6,k-mahoney.9p18idhz,nicki.8a8nff82",
             "type": "vector"
         }
     },

--- a/app.js
+++ b/app.js
@@ -26,7 +26,7 @@ map.on('load', function() {
   var corridorInfo = [
     {
       id: 'crashes-total',
-      text: 'total crashes',
+      text: 'Total crashes',
       geomType: 'point',
       data: turf.featureCollection(map.querySourceFeatures('composite', {
         sourceLayer: 'Crashes_in_DC-d0weq7'
@@ -34,7 +34,7 @@ map.on('load', function() {
     },
     {
       id: 'crashes-cyclists',
-      text: 'bike-related crashes',
+      text: 'Bike-related crashes',
       geomType: 'point',
       data: turf.featureCollection(map.querySourceFeatures('composite', {
         sourceLayer: 'Crashes_in_DC-d0weq7',
@@ -43,7 +43,7 @@ map.on('load', function() {
     },
     {
       id: 'crashes-pedestrians',
-      text: 'pedestrian-related crashes',
+      text: 'Pedestrian-related crashes',
       geomType: 'point',
       data: turf.featureCollection(map.querySourceFeatures('composite', {
         sourceLayer: 'Crashes_in_DC-d0weq7',
@@ -52,27 +52,78 @@ map.on('load', function() {
     },
     {
       id: 'population',
-      text: 'population',
+      text: 'Population',
       geomType: 'polygon',
       data: turf.featureCollection(map.querySourceFeatures('composite', {
         sourceLayer: 'combined_features-7kmirr'
       })),
-      measurements: ['population_total']
+      dataFields: ['population_total']
     },
     {
       id: 'modeshare',
-      text: 'modeshare',
+      text: 'Modeshare',
+      secondaryText: [
+        'Bicycle',
+        'Automotive',
+        'Walking',
+        'Public transportation'
+      ],
       geomType: 'polygon',
       data: turf.featureCollection(map.querySourceFeatures('composite', {
         sourceLayer: 'combined_features-7kmirr',
       })),
-      measurements: [
+      dataFields: [
         'transport_bicycle',
         'transport_car_truck_or_van',
         'transport_walked',
         'transport_public_transportation_excluding_taxicab'
         ],
       total: 'transport_total'
+    },
+    {
+      id: 'income',
+      text: 'Income',
+      secondaryText: [
+        '<10,000',
+        '10,000–14,999',
+        '15,000–19,999',
+        '20,000–24,999',
+        '25,000–29,999',
+        '30,000–34,999',
+        '35,000–39,999',
+        '40,000–44,999',
+        '45,000–49,999',
+        '50,000–59,999',
+        '60,000–74,999',
+        '5,000–99,999',
+        '100,000–124,999',
+        '125,000–149,999',
+        '150,000–199,999',
+        '>200,000'
+      ],
+      geomType: 'polygon',
+      data: turf.featureCollection(map.querySourceFeatures('composite', {
+        sourceLayer: 'combined_features-7kmirr',
+      })),
+      dataFields: [
+        'income_less_than_10_000',
+        'income_10_000_to_14_999',
+        'income_15_000_to_19_999',
+        'income_20_000_to_24_999',
+        'income_25_000_to_29_999',
+        'income_30_000_to_34_999',
+        'income_35_000_to_39_999',
+        'income_40_000_to_44_999',
+        'income_45_000_to_49_999',
+        'income_50_000_to_59_999',
+        'income_60_000_to_74_999',
+        'income_75_000_to_99_999',
+        'income_100_000_to_124_999',
+        'income_125_000_to_149_999',
+        'income_150_000_to_199_999',
+        'income_200_000_or_more'
+        ],
+      total: 'income_total'
     }
   ];
 
@@ -80,6 +131,7 @@ map.on('load', function() {
   //console.log(corridorInfo[3]);
 
   // Display census data on map to help debug
+  /*
   map.addLayer(
     {
       "id": "census-blocks",
@@ -108,6 +160,7 @@ map.on('load', function() {
       }
     }
   );
+  */
 
   map.addControl(draw);
 
@@ -124,6 +177,7 @@ map.on('load', function() {
     var bufferedCorridor = turf.buffer(corridor, 10, {units: 'meters'});
 
     // Display buffered corridor on map to help debug
+    /*
     map.addLayer(
       {
         "id": "bufferedCorridor",
@@ -134,10 +188,10 @@ map.on('load', function() {
         "type": "fill",
         "paint": {
           "fill-color": "#f00",
-          "fill-opacity": 0.5
+          "fill-opacity": 0.25
         }
       }
-    );
+    );*/
 
     for (item in corridorInfo) {
       // Type: Point
@@ -147,11 +201,14 @@ map.on('load', function() {
 
       // Type: Polygon
       if (corridorInfo[item].geomType === "polygon") {
-        var measurements = corridorInfo[item].measurements;
-        var totalCount = [];
-        measurements.forEach(function(){
-           totalCount.push(0);
-        });
+        var dataFields = corridorInfo[item].dataFields;
+        var count = [];
+        if (corridorInfo[item].total) {
+          var totalCount = 0;
+        }
+        dataFields.forEach(function() {
+          count.push(0);
+        })
         // Iterate through features to check for corridor overlap
         //console.log(corridorInfo[item]);
         for (i in corridorInfo[item].data.features) {
@@ -166,17 +223,35 @@ map.on('load', function() {
             // TODO: dedupe tiles using GEOID property (this is unique by block. Is there a better property?)
             // TODO: add optional % calculation
             // TODO: figure out why this function does seem to capture all intersecting census blocks
-            for (j in measurements) {
-            totalCount[j] += +feature.properties[measurements[j]];
+            for (j in dataFields) {
+            count[j] += +feature.properties[dataFields[j]];
             }
+            //if (corridorInfo[item].total) {
+            //totalCount += +feature.properties[total];
+            //var count = count / totalCount * 100;
+            //}
           }
-          var data = totalCount;
+          
+          var data = count;
         }
-      }
+      }  
 
       // Creates new rows in the table the first time a line is drawn
       // Replaces old data each time a new line is drawn
       // (There's probably better ways to update the table)
+
+      /*if (document.getElementById('corridor-info-table').rows.length > item) {
+        var row = document.getElementById(corridorInfo[item].id);
+        var desc = row.cells[0];
+        var more = row.cells[1];
+      } else {
+        var row = document.getElementById('corridor-info-table').insertRow(-1);
+        row.id = corridorInfo[item].id;
+        //console.log("Added row in corridor info table: " + row.id);
+        var desc = row.insertCell(0);
+        var more = row.insertCell(1);
+      };*/
+
       if (document.getElementById('corridor-info-table').rows.length > item) {
         var row = document.getElementById(corridorInfo[item].id);
         var desc = row.cells[0];
@@ -194,7 +269,13 @@ map.on('load', function() {
         desc.innerHTML =  corridorInfo[item].text + ': ' + '<span class="txt-bold">' + data[0] + '</span> ';
       } else {
         // TODO: Add additional rows for the sub-items
-        desc.innerHTML =  corridorInfo[item].text + ': ' + '<span class="txt-bold">' + "test" + '</span> ';
+        desc.innerHTML =  corridorInfo[item].text + '</br>';
+        for (j in corridorInfo[item].secondaryText) {
+          desc.innerHTML += '<p class=secondaryText>' + corridorInfo[item].secondaryText[j] + ': ' + '<span class="txt-bold">' + data[j] + '</span></p>';
+          //var secondaryText = document.createElement('p');
+          //secondaryText.innerHTML = '<p>' + corridorInfo[item].secondaryText[j] + ': ' + '<span class="txt-bold">' + data[j] + '</span></p>';
+          //desc.appendChild(secondaryText);
+        }
       };
       // "More" section is a placeholder for accessing:
       // 1. Information about the data the statistic was derived from

--- a/app.js
+++ b/app.js
@@ -1,23 +1,18 @@
 mapboxgl.accessToken = 'pk.eyJ1Ijoibmlja2kiLCJhIjoiczVvbFlXQSJ9.1Gegt3V_MTupW6wfjxq2QA';
 
 var map = new mapboxgl.Map({
-    container: 'map',
-    //style: 'mapbox://styles/nicki/cjav7yuqylrmk2speysk7tz9y',
-    style: 'add-bike-lane-style.json',
-    center: [-77.007945, 38.896870],
-    zoom: 12
+  container: 'map',
+  style: 'mapbox://styles/nicki/cjav7yuqylrmk2speysk7tz9y',
+  center: [-77.007945, 38.896870],
+  zoom: 12
 });
 
 var draw = new MapboxDraw({
-    controls: {
-        point: false,
-        polygon: false
-    }
+  controls: {
+    point: false,
+    polygon: false
+  }
 });
-
-map.addControl(draw);
-
-map.on('load', function() {
 
 // Since we are planning to also visualize the corridor data on the map, it's probably
 // easiest to reuse the vector tiles for data querying.
@@ -26,98 +21,102 @@ map.on('load', function() {
 // However, the `REPORTDATE` field contains string values, not numbers, so we may want to reformat these first
 // although it would make data updates easier if we didn't reformat it...
 
-	var corridorInfo = [
-		{
-			id: 'crashes-total',
-			text: 'Total crashes',
-			geomType: 'point',
-			data: turf.featureCollection(map.querySourceFeatures('composite', {
-				sourceLayer: 'Crashes_in_DC-d0weq7'
-				}))
-		},
-		{
-			id: 'crashes-cyclists',
-			text: 'Bike-related crashes',
-			geomType: 'point',
-			data: turf.featureCollection(map.querySourceFeatures('composite', {
-				sourceLayer: 'Crashes_in_DC-d0weq7',
-				filter: ['>', 'TOTAL_BICY', 0]
-				}))
-		},
-		{
-			id: 'crashes-pedestrians',
-			text: 'Pedestrian-related crashes',
-			geomType: 'point',
-			data: turf.featureCollection(map.querySourceFeatures('composite', {
-				sourceLayer: 'Crashes_in_DC-d0weq7',
-				filter: ['>', 'TOTAL_PEDE', 0]
-				}))
-		},
-		{
-			id: 'population',
-			text: 'Population',
-			geomType: 'polygon',
-			data: turf.featureCollection(map.querySourceFeatures('composite', {
-				sourceLayer: 'combined_features-7kmirr'
-				}))
-		}/*,
-		{
-			id: 'modeshare',
-			text: 'Modeshare',
-			geomType: 'polygon',
-			data: null
-		}*/
-	];
+map.on('load', function() {
+  var corridorInfo = [
+    {
+      id: 'crashes-total',
+      text: 'total crashes',
+      geomType: 'point',
+      data: turf.featureCollection(map.querySourceFeatures('composite', {
+        sourceLayer: 'Crashes_in_DC-d0weq7'
+      }))
+    },
+    {
+      id: 'crashes-cyclists',
+      text: 'bike-related crashes',
+      geomType: 'point',
+      data: turf.featureCollection(map.querySourceFeatures('composite', {
+        sourceLayer: 'Crashes_in_DC-d0weq7',
+        filter: ['>', 'TOTAL_BICY', 0]
+      }))
+    },
+    {
+      id: 'crashes-pedestrians',
+      text: 'pedestrian-related crashes',
+      geomType: 'point',
+      data: turf.featureCollection(map.querySourceFeatures('composite', {
+        sourceLayer: 'Crashes_in_DC-d0weq7',
+        filter: ['>', 'TOTAL_PEDE', 0]
+      }))
+    },
+    {
+      id: 'population',
+      text: 'Population',
+      geomType: 'polygon',
+      data: turf.featureCollection(map.querySourceFeatures('composite', {
+        sourceLayer: 'combined_features-7kmirr'
+      }))
+    }
+  ];
 
-	map.on('draw.create', updateCorridor);
-	map.on('draw.delete', updateCorridor);
-	map.on('draw.update', updateCorridor);
+  console.log(corridorInfo[3]);
 
-	function updateCorridor(e) {
-		var corridor = draw.getAll();
-		// Currently, this allows you to draw multiple unconnected lines as a "corridor"
-		var bufferedCorridor = turf.buffer(corridor, 10, {units: 'meters'});
-		for (var i = 0; i < corridorInfo.length; i++) {
-			// var data will need to be assigned differently depending on the source
-			// current implementation only works for points
-			if (corridorInfo[i].geomType = "point") {
-				var data = turf.pointsWithinPolygon(corridorInfo[i].data, bufferedCorridor).features.length;	
-			}
-			/*else {
-				// polygons
-				//var data = turf.intersect(corridorInfo[i].data, bufferedCorridor).features.length;
-				console.log(corridorInfo[3].data.features);
-				for (i in corridorInfo[3].data.features) {
-					var feature = corridorInfo[3].data.features[i];
+  map.addControl(draw);
 
-					if (turf.booleanOverlap(bufferedCorridor, feature)) {
-						console.log(feature.properties.population_total);
-					}
-				};
-				
-			};*/
-			// Creates new rows in the table the first time a line is drawn
-			// Replaces old data each time a new line is drawn
-			// (There's probably better ways to update the table):
-			if (document.getElementById('corridor-info-table').rows.length > i) {
-				var row = document.getElementById(corridorInfo[i].id);
-				var desc = row.cells[0];
-				var more = row.cells[1];
-			} else {
-				var row = document.getElementById('corridor-info-table').insertRow(-1);
-				row.id = corridorInfo[i].id;
-				console.log(row.id);
-				var desc = row.insertCell(0);
-				var more = row.insertCell(1);
-			};
-			desc.innerHTML =  corridorInfo[i].text + ': ' + '<span class="txt-bold">' + data + '</span> ';
-			// "More" section is a placeholder for accessing:
-			// 1. Information about the data the statistic was derived from 
-			// (we could also consolidate all the data info in one place elsewhere)
-			// 2. Toggling on/off visualizations on the map for that statistic
-			more.innerHTML = '<svg class="icon inline"><use xlink:href="#icon-question"/></svg> <svg class="icon inline"><use xlink:href="#icon-map"/></svg>'
-		};
-		document.getElementById('corridor-info').style.visibility = 'visible';
-	}
+  map.on('draw.create', updateCorridor);
+  map.on('draw.delete', updateCorridor);
+  map.on('draw.update', updateCorridor);
+
+  function updateCorridor(e) {
+    // Currently, this allows you to draw multiple unconnected lines as a "corridor"
+    var corridor = draw.getAll();
+
+    // Buffer the corridor to include adjacent point features in returned data
+    var bufferedCorridor = turf.buffer(corridor, 10, {units: 'meters'});
+
+    for (item in corridorInfo) {
+      // Type: Point
+      if (corridorInfo[item].geomType === "point") {
+        var data = turf.pointsWithinPolygon(corridorInfo[item].data, bufferedCorridor).features.length;
+      }
+
+      // Type: Polygon
+      if (corridorInfo[item].geomType === "polygon") {
+        // Iterate through features to check for corridor overlap
+        console.log(corridorInfo[item]);
+        for (i in corridorInfo[item].data.features) {
+          console.log("STUFF HAPPENED");
+          var feature = corridorInfo[item].data.features[i];
+          console.log(feature);
+          if (turf.booleanOverlap(bufferedCorridor, feature)) {
+            console.log(feature.properties.population_total);
+          }
+        };
+      }
+
+      // Creates new rows in the table the first time a line is drawn
+      // Replaces old data each time a new line is drawn
+      // (There's probably better ways to update the table)
+      if (document.getElementById('corridor-info-table').rows.length > item) {
+        var row = document.getElementById(corridorInfo[item].id);
+        var desc = row.cells[0];
+        var more = row.cells[1];
+      } else {
+        var row = document.getElementById('corridor-info-table').insertRow(-1);
+        row.id = corridorInfo[item].id;
+        console.log(row.id);
+        var desc = row.insertCell(0);
+        var more = row.insertCell(1);
+      };
+
+      desc.innerHTML =  corridorInfo[item].text + ': ' + '<span class="txt-bold">' + data + '</span> ';
+      // "More" section is a placeholder for accessing:
+      // 1. Information about the data the statistic was derived from
+      // (we could also consolidate all the data info in one place elsewhere)
+      // 2. Toggling on/off visualizations on the map for that statistic
+      more.innerHTML = '<svg class="icon inline"><use xlink:href="#icon-question"/></svg> <svg class="icon inline"><use xlink:href="#icon-map"/></svg>'
+    };
+    document.getElementById('corridor-info').style.visibility = 'visible';
+  }
 });
 

--- a/app.js
+++ b/app.js
@@ -2,7 +2,8 @@ mapboxgl.accessToken = 'pk.eyJ1Ijoibmlja2kiLCJhIjoiczVvbFlXQSJ9.1Gegt3V_MTupW6wf
 
 var map = new mapboxgl.Map({
     container: 'map',
-    style: 'mapbox://styles/nicki/cjav7yuqylrmk2speysk7tz9y',
+    //style: 'mapbox://styles/nicki/cjav7yuqylrmk2speysk7tz9y',
+    style: 'add-bike-lane-style.json',
     center: [-77.007945, 38.896870],
     zoom: 12
 });
@@ -28,14 +29,16 @@ map.on('load', function() {
 	var corridorInfo = [
 		{
 			id: 'crashes-total',
-			text: 'total crashes',
+			text: 'Total crashes',
+			geomType: 'point',
 			data: turf.featureCollection(map.querySourceFeatures('composite', {
 				sourceLayer: 'Crashes_in_DC-d0weq7'
 				}))
 		},
 		{
 			id: 'crashes-cyclists',
-			text: 'bike-related crashes',
+			text: 'Bike-related crashes',
+			geomType: 'point',
 			data: turf.featureCollection(map.querySourceFeatures('composite', {
 				sourceLayer: 'Crashes_in_DC-d0weq7',
 				filter: ['>', 'TOTAL_BICY', 0]
@@ -43,12 +46,27 @@ map.on('load', function() {
 		},
 		{
 			id: 'crashes-pedestrians',
-			text: 'pedestrian-related crashes',
+			text: 'Pedestrian-related crashes',
+			geomType: 'point',
 			data: turf.featureCollection(map.querySourceFeatures('composite', {
 				sourceLayer: 'Crashes_in_DC-d0weq7',
 				filter: ['>', 'TOTAL_PEDE', 0]
 				}))
-		}
+		},
+		{
+			id: 'population',
+			text: 'Population',
+			geomType: 'polygon',
+			data: turf.featureCollection(map.querySourceFeatures('composite', {
+				sourceLayer: 'combined_features-7kmirr'
+				}))
+		}/*,
+		{
+			id: 'modeshare',
+			text: 'Modeshare',
+			geomType: 'polygon',
+			data: null
+		}*/
 	];
 
 	map.on('draw.create', updateCorridor);
@@ -62,7 +80,22 @@ map.on('load', function() {
 		for (var i = 0; i < corridorInfo.length; i++) {
 			// var data will need to be assigned differently depending on the source
 			// current implementation only works for points
-			var data = turf.pointsWithinPolygon(corridorInfo[i].data, bufferedCorridor).features.length;
+			if (corridorInfo[i].geomType = "point") {
+				var data = turf.pointsWithinPolygon(corridorInfo[i].data, bufferedCorridor).features.length;	
+			}
+			/*else {
+				// polygons
+				//var data = turf.intersect(corridorInfo[i].data, bufferedCorridor).features.length;
+				console.log(corridorInfo[3].data.features);
+				for (i in corridorInfo[3].data.features) {
+					var feature = corridorInfo[3].data.features[i];
+
+					if (turf.booleanOverlap(bufferedCorridor, feature)) {
+						console.log(feature.properties.population_total);
+					}
+				};
+				
+			};*/
 			// Creates new rows in the table the first time a line is drawn
 			// Replaces old data each time a new line is drawn
 			// (There's probably better ways to update the table):
@@ -77,7 +110,7 @@ map.on('load', function() {
 				var desc = row.insertCell(0);
 				var more = row.insertCell(1);
 			};
-			desc.innerHTML =  '<span class="txt-bold">' + data + '</span> ' + corridorInfo[i].text;
+			desc.innerHTML =  corridorInfo[i].text + ': ' + '<span class="txt-bold">' + data + '</span> ';
 			// "More" section is a placeholder for accessing:
 			// 1. Information about the data the statistic was derived from 
 			// (we could also consolidate all the data info in one place elsewhere)

--- a/app.js
+++ b/app.js
@@ -51,6 +51,16 @@ map.on('load', function() {
       }))
     },
     {
+      id: 'speeding-violations',
+      text: 'Speeding violations',
+      geomType: 'point',
+      data: turf.featureCollection(map.querySourceFeatures('composite', {
+        // Currently only Dec 2018 data
+        sourceLayer: 'moving-violations-dec-2018-re-7lav76',
+        filter: ['in', 'VIOLATIONCODE', "T118", "T119", "T120", "T121", "T122"]
+      }))
+    },
+    {
       id: 'population',
       text: 'Population',
       geomType: 'polygon',
@@ -82,7 +92,7 @@ map.on('load', function() {
         'transport_motorcycle',
         'transport_public_transportation_excluding_taxicab',
         'transport_taxicab',
-        'transport_other'
+        'transport_other_means'
         ],
       total: 'transport_total'
     },

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <h3 class='txt-m txt-bold mb6'>Add a bike lane</h3>
         <p>Use the controls in the sidepanel to draw a bike lane on the map. Double-click the end point to "add" your bike lane.</p>
         <div id='corridor-info' class='mt12'>
-          <p>On this corridor, there have been:</p>
+          <p>Along this corridor:</p>
           <table id='corridor-info-table' class='table mt12'>
           </table>
       </div>  

--- a/style.css
+++ b/style.css
@@ -9,3 +9,6 @@ body { margin:0; padding:0; }
 	border-style: none; 
 	padding: 6px;
 }
+.secondaryText {
+	font-size: 80%;
+}


### PR DESCRIPTION
Adds the remaining data to corridor info display, per https://github.com/mapbox/waba-add-a-bike-lane/issues/1#issuecomment-349805426:

- Speeding violations
- Population
- Modeshare
- Income

/cc @k-mahoney @peterqliu